### PR TITLE
! intermittent failure codecov.yml validation

### DIFF
--- a/Codecov/Assert-ValidCodecovYML.psm1
+++ b/Codecov/Assert-ValidCodecovYML.psm1
@@ -58,7 +58,7 @@ function Assert-ValidCodecovYML {
       try {
         $output = Invoke-RestMethod -Uri https://codecov.io/validate `
           -Body (Get-Content -Raw -LiteralPath ($Path[0].Path)) -Method POST
-      } catch {
+      } catch [System.Net.WebException] {
         if ($_.Exception.Response.StatusCode.value__) {
           $details = (
             $_.Exception.Response.StatusCode.value__).ToString().Trim()

--- a/Codecov/Assert-ValidCodecovYML.psm1
+++ b/Codecov/Assert-ValidCodecovYML.psm1
@@ -59,14 +59,19 @@ function Assert-ValidCodecovYML {
         $output = Invoke-RestMethod -Uri https://codecov.io/validate `
           -Body (Get-Content -Raw -LiteralPath ($Path[0].Path)) -Method POST
       } catch {
+        if ($_.Exception.Response.StatusCode.value__) {
+          $details = (
+            $_.Exception.Response.StatusCode.value__).ToString().Trim()
+        }
         if ($PSVersionTable.PSVersion.Major -lt 6) { # confirmed for v5.1
-          $details= "($(
-            $_.Exception.Response.StatusCode.value__)) $(
-            $_.Exception.Response.StatusDescription)"
+          if ($_.Exception.Response.StatusDescription) {
+            $details += (
+              $_.Exception.Response.StatusDescription).ToString().Trim()
+          }
         } else { # confirmed for v6.1.2
-          $details= "($(
-            $_.Exception.Response.StatusCode.value__)) $(
-            $_.Exception.Response.ReasonPhrase)"
+          if ($_.Exception.Response.ReasonPhrase) {
+            $details += ($_.Exception.Response.ReasonPhrase).ToString().Trim()
+          }
         }
         Send-Message -Error -Message `
           "Validation of Codecov YAML failed!" `


### PR DESCRIPTION
On AppVeyor, only for the VS2017 image, the `Assert-ValidCodecovYML` test with a valid sample sometimes fails.

Example: [Build 39](https://ci.appveyor.com/project/Farwaykorse/appveyorhelpers/builds/25891721)

-----
Additionally, by only catching `WebException`, other script errors are still reported. Instead of failing on the nonexistence of the subvariable `Response` in `$_.Exception.Response.StatusCode.value__`.