### PR TITLE
Show-SystemInfo v0.2

### DIFF
--- a/AppVeyorGeneral/Show-SystemInfo.Tests.ps1
+++ b/AppVeyorGeneral/Show-SystemInfo.Tests.ps1
@@ -41,12 +41,13 @@ Describe 'Internal Join-Info' {
       }
     }
     Context 'Basic operation' {
-      It 'align to default length of 15' {
-        $Align = 15
+      It 'align to default length of 20' {
+        $Align = 20
         Join-Info 'some' 'text' | Should -Match 'some:.*text'
-        (Join-Info 'some' 'text').Length | Should -Be 19 -Because '15+4'
-        Join-Info 'some' 'text' | Should -MatchExactly 'some:          text' `
-          -Because 'default Length = 15'
+        (Join-Info 'some' 'text').Length | Should -Be 24 -Because '20+4'
+        Join-Info 'some' 'text' |
+          Should -MatchExactly 'some:               text' `
+          -Because 'default Length = 20'
         Join-Info 'some' 'text' |
           Should -not -MatchExactly 'some:    text' -Because 'test-error'
       }
@@ -201,11 +202,11 @@ Describe 'Show-SystemInfo' {
     }
   }
   Context 'Setting Align' {
-    It 'default alignment (15 characters)' {
-      Show-SystemInfo | Should -match '\n.{14} [^ ]'
+    It 'default alignment (20 characters)' {
+      Show-SystemInfo | Should -match '\n.{19} [^ ]'
     }
-    It '-Align 20' {
-      Show-SystemInfo -Align 20 | Should -match '\n.{19} [^ ]'
+    It '-Align 25' {
+      Show-SystemInfo -Align 25 | Should -match '\n.{24} [^ ]'
     }
   }
   Context 'mock (not) on CI' {

--- a/AppVeyorGeneral/Show-SystemInfo.Tests.ps1
+++ b/AppVeyorGeneral/Show-SystemInfo.Tests.ps1
@@ -106,7 +106,7 @@ Describe 'Internal Show-<software>Version' {
       }
       It 'return version number' {
         if (-not $available) {
-          Set-ItResult -Inconclusive -Because ('no cmake')
+          Set-ItResult -Inconclusive -Because ('no CMake')
         }
         Show-CMakeVersion | Should -match '^([0-9]+\.)+[0-9]+(-rc)?$'
       }
@@ -144,7 +144,7 @@ Describe 'Internal Show-<software>Version' {
         if (-not $available) {
           Set-ItResult -Inconclusive -Because ('no clang-cl')
         }
-        Show-LLVMVersion | Should -match '^([0-9]+\.)+[0-9]$'
+        Show-LLVMVersion | Should -match '^([0-9]+\.)+[0-9]+$'
       }
     }
     Context 'mock software unavailable' {

--- a/AppVeyorGeneral/Show-SystemInfo.Tests.ps1
+++ b/AppVeyorGeneral/Show-SystemInfo.Tests.ps1
@@ -130,7 +130,7 @@ Describe 'Internal Show-<software>Version' {
       }
       It 'return version number' {
         if (-not $available) {
-          Set-ItResult -Inconclusive -Because ('no cmake')
+          Set-ItResult -Inconclusive -Because ('no python')
         }
         Show-PythonVersion | Should -match '^([0-9]+\.)+[0-9]+$'
       }
@@ -142,7 +142,7 @@ Describe 'Internal Show-<software>Version' {
       }
       It 'return version number' {
         if (-not $available) {
-          Set-ItResult -Inconclusive -Because ('no cmake')
+          Set-ItResult -Inconclusive -Because ('no clang-cl')
         }
         Show-LLVMVersion | Should -match '^([0-9]+\.)+[0-9]$'
       }

--- a/AppVeyorGeneral/Show-SystemInfo.Tests.ps1
+++ b/AppVeyorGeneral/Show-SystemInfo.Tests.ps1
@@ -147,6 +147,18 @@ Describe 'Internal Show-<software>Version' {
         Show-LLVMVersion | Should -match '^([0-9]+\.)+[0-9]+$'
       }
     }
+    Context 'Curl' {
+      $available = $(Test-Command 'curl.exe -V')
+      It 'no throw' {
+          { Show-CurlVersion } | Should -not -Throw
+      }
+      It 'return version number' {
+        if (-not $available) {
+          Set-ItResult -Inconclusive -Because ('no Curl')
+        }
+        Show-CurlVersion | Should -match '^([0-9]+\.)+[0-9]+$'
+      }
+    }
     Context 'mock software unavailable' {
       Mock Test-Command { return $false } -ModuleName Show-SystemInfo
       It 'CMake' {
@@ -160,6 +172,9 @@ Describe 'Internal Show-<software>Version' {
       }
       It 'LLVM' {
         Show-LLVMVersion | Should -MatchExactly ' ?'
+      }
+      It 'Curl' {
+        Show-CurlVersion | Should -MatchExactly ' ?'
       }
     }
   }
@@ -189,6 +204,9 @@ Describe 'Show-SystemInfo' {
     }
     It 'no throw on -SevenZip' {
       { Show-SystemInfo -SevenZip } | Should -not -Throw
+    }
+    It 'no throw on -Curl' {
+      { Show-SystemInfo -Curl } | Should -not -Throw
     }
     It 'no throw on -All' {
       { Show-SystemInfo -All } | Should -not -Throw

--- a/AppVeyorGeneral/Show-SystemInfo.Tests.ps1
+++ b/AppVeyorGeneral/Show-SystemInfo.Tests.ps1
@@ -124,7 +124,8 @@ Describe 'Internal Show-<software>Version' {
       }
     }
     Context 'Python' {
-      $available = $(Test-Command 'python --version')
+      # Note: Python v2.7 writes to error stream:
+      $available = $(Test-Command 'python --version 2>$null')
       It 'no throw' {
           { Show-PythonVersion } | Should -not -Throw
       }

--- a/AppVeyorGeneral/Show-SystemInfo.psd1
+++ b/AppVeyorGeneral/Show-SystemInfo.psd1
@@ -6,7 +6,7 @@
 #>
 @{
 RootModule = 'Show-SystemInfo.psm1'
-ModuleVersion = '0.1'
+ModuleVersion = '0.2'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/AppVeyorGeneral/Show-SystemInfo.psm1
+++ b/AppVeyorGeneral/Show-SystemInfo.psm1
@@ -10,46 +10,46 @@ Set-StrictMode -Version Latest
 .EXAMPLE
   Show-SystemInfo
   -- CI Session Configuration --
-  OS / platform: Microsoft Windows Server 2019 Datacenter / 64-bit
-  Image:         Visual Studio 2019
-  Configuration: Debug
-  Platform:      x64
-  -------------------------------------------------------------
-  Initial path:  C:\projects\sampleproject
+  OS / platform:      Microsoft Windows Server 2019 Datacenter / 64-bit
+  Image:              Visual Studio 2019
+  Configuration:      Debug
+  Platform:           x64
+  ------------------------------------------------------------------------------
+  Initial path:       C:\projects\sampleproject
 .EXAMPLE
   Show-SystemInfo -PowerShell -CMake
   -- CI Session Configuration --
-  OS / platform: Microsoft Windows Server 2019 Datacenter / 64-bit
-  Image:         Visual Studio 2019
-  Configuration: Debug
-  Platform:      x64
-  PowerShell:    5.1.17763.503
-  PS Core:       6.2.0
-  CMake:         3.14.4
-  -------------------------------------------------------------
-  Initial path:  C:\projects\sampleproject
+  OS / platform:      Microsoft Windows Server 2019 Datacenter / 64-bit
+  Image:              Visual Studio 2019
+  Configuration:      Debug
+  Platform:           x64
+  PowerShell:         5.1.17763.503
+  PS Core:            6.2.0
+  CMake:              3.14.4
+  ------------------------------------------------------------------------------
+  Initial path:       C:\projects\sampleproject
 .EXAMPLE
   Show-SystemInfo -All | Send-Message 'SystemInfo' -HideDetails
   -- CI Session Configuration --
   OS / platform: Microsoft Windows Server 2019 Datacenter / 64-bit
-  Image:         Visual Studio 2019
-  Configuration: Debug
-  Platform:      x64
-  PowerShell:    5.1.17763.503
-  PS Core:       6.2.0
-  7-zip:         19.00
-  LLVM/clang:    8.0.0
-  CMake:         3.14.4
-  Python:        2.7.16
-  -------------------------------------------------------------
-  Initial path:  C:\projects\sampleproject
+  Image:              Visual Studio 2019
+  Configuration:      Debug
+  Platform:           x64
+  PowerShell:         5.1.17763.503
+  PS Core:            6.2.0
+  7-zip:              19.00
+  LLVM/clang:         8.0.0
+  CMake:              3.14.4
+  Python:             2.7.16
+  ------------------------------------------------------------------------------
+  Initial path:       C:\projects\sampleproject
 #>
 function Show-SystemInfo {
   param(
     [ValidateScript({ $_ -ge 0 })]
     [Alias('ColumnWidth')]
-    # Alignment of data/ first column width (default 15 characters).
-    [Int]$Align = 15,
+    # Alignment of data/ first column width (default 20 characters).
+    [Int]$Align = 20,
     [switch]$All,
     [switch]$CMake,
     [switch]$LLVM,
@@ -141,15 +141,15 @@ function Show-SystemInfo {
 
 <#
 .SYNOPSIS
-  Return "<Info>:   <Data>" with constant alignment.
+  Return "<Info>:        <Data>" with constant alignment.
 .EXAMPLE
   Join-Info 'Some item' 'The information regarding this item.'
-  Some item:    The information regarding this item.'
-.EXAMPLE
-  Join-Info 'Some item' 'The information regarding this item.' -Length 20
   Some item:         The information regarding this item.'
 .EXAMPLE
-  Join-Info 'Long item name' 'The information regarding this item.'
+  Join-Info 'Some item' 'The information regarding this item.' -Length 15
+  Some item:    The information regarding this item.'
+.EXAMPLE
+  Join-Info 'Long item name' 'The information regarding this item.' -Length 5
   Long item name: The information regarding this item.'
 
   A string longer then the set Length shifts the Data item out of alignment.

--- a/AppVeyorGeneral/Show-SystemInfo.psm1
+++ b/AppVeyorGeneral/Show-SystemInfo.psm1
@@ -55,7 +55,8 @@ function Show-SystemInfo {
     [switch]$LLVM,
     [switch]$PowerShell,
     [switch]$Python,
-    [switch]$SevenZip
+    [switch]$SevenZip,
+    [switch]$Curl
   )
   Begin
   {
@@ -81,6 +82,7 @@ function Show-SystemInfo {
     if (Assert-CI) {
       $out += ('-- CI Session Configuration --').PadRight(80,'-')
     } else { $out += ('-- Local System Configuration --').PadRight(80,'-') }
+    # System
     $out += Join-Info 'OS / platform' $(
       if ($PSVersionTable.PSVersion.Major -lt 6) {
         $((Get-WmiObject Win32_OperatingSystem).Caption) + ' / ' +
@@ -90,6 +92,7 @@ function Show-SystemInfo {
         $((Get-CimInstance CIM_OperatingSystem).OSArchitecture)
       }
     )
+    # AppVeyor default matrix 
     if (Assert-CI -and $env:APPVEYOR_BUILD_WORKER_IMAGE) {
       $out += Join-Info 'Image' $env:APPVEYOR_BUILD_WORKER_IMAGE
     }
@@ -123,6 +126,7 @@ function Show-SystemInfo {
     if ($LLVM -or $All)     { $out += Join-Info LLVM/clang $(Show-LLVMVersion) }
     if ($CMake -or $All)    { $out += Join-Info CMake $(Show-CMakeVersion) }
     if ($Python -or $All)   { $out += Join-Info Python $(Show-PythonVersion) }
+    if ($Curl -or $All)     { $out += Join-Info Curl $(Show-CurlVersion) }
   }
   Process
   {
@@ -226,6 +230,21 @@ function Show-LLVMVersion {
     return (
       ($(clang-cl --version) | Select-String -Pattern version) -split ' ' |
         Select-String -Pattern '^[0-9].+'
+    )
+  } else { return ' ?' }
+}
+
+<#
+.SYNOPSIS
+  Acquire the version number from Curl.
+#>
+function Show-CurlVersion {
+  [OutputType([String])]
+  param()
+  if (Test-Command 'curl.exe -V') {
+    return (
+      $(curl.exe -V) -split ' ' |
+        Select-String -Pattern '^([0-9]+\.)+[0-9]+.*'
     )
   } else { return ' ?' }
 }

--- a/AppVeyorGeneral/Show-SystemInfo.psm1
+++ b/AppVeyorGeneral/Show-SystemInfo.psm1
@@ -203,12 +203,15 @@ function Show-7zipVersion {
 <#
 .SYNOPSIS
   Acquire the version number from the default python install.
+.NOTES
+  Python v2.7 outputs to the error stream.
 #>
 function Show-PythonVersion {
   [OutputType([String])]
   param()
-  if (Test-Command 'python --version') {
-    return ($(python --version) -split ' ' | Select-String -Pattern '^[0-9].+')
+  if (Test-Command 'python --version 2>$null') {
+    return ( ($(python --version) 2>&1) -split ' ' |
+      Select-String -Pattern '^[0-9].+' )
   } else { return ' ?' }
 }
 

--- a/AppVeyorHelpers.psd1
+++ b/AppVeyorHelpers.psd1
@@ -7,7 +7,7 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = ''
-ModuleVersion = '0.10'
+ModuleVersion = '0.10.1'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/AppVeyorHelpers.psd1
+++ b/AppVeyorHelpers.psd1
@@ -7,7 +7,7 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = ''
-ModuleVersion = '0.9'
+ModuleVersion = '0.10'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ for:
     - configuration: PowerShell
   install:
   - ps: Import-Module -Name .\AppVeyorHelpers.psd1
-  - ps: Show-SystemInfo -PowerShell
+  - ps: Show-SystemInfo -All
   - ps: Install-Module Pester -Force
   - ps: >-
       ( Get-Module Pester -ListAvailable |
@@ -51,7 +51,7 @@ for:
   install:
   - pwsh: |
       Import-Module -Name .\AppVeyorHelpers.psd1
-      Show-SystemInfo -PowerShell
+      Show-SystemInfo -All
   - pwsh: Install-Module Pester -Force
   - pwsh: >-
       ( Get-Module Pester -ListAvailable |


### PR DESCRIPTION
- new: `Show-SystemInfo -Curl`
- change: default alignment/ width first column to 20 characters (was 15).
- fix: forgot to increase the version number in PR #8
- fix: processing version numbers from Python v2.7 (from error stream)

Version 0.10.1