### PR TITLE
Update-Vcpkg

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@ for:
     - configuration: PowerShell
   install:
   - ps: Import-Module -Name .\AppVeyorHelpers.psd1
-  - ps: Show-SystemInfo -All
+  - ps: Show-SystemInfo -Path -All
   - ps: Install-Module Pester -Force
   - ps: >-
       ( Get-Module Pester -ListAvailable |
@@ -51,7 +51,7 @@ for:
   install:
   - pwsh: |
       Import-Module -Name .\AppVeyorHelpers.psd1
-      Show-SystemInfo -All
+      Show-SystemInfo -Path -All
   - pwsh: Install-Module Pester -Force
   - pwsh: >-
       ( Get-Module Pester -ListAvailable |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,6 +38,7 @@ for:
       ( Get-Module Pester -ListAvailable |
       Format-Table -HideTableHeaders -Property Name, Version |
       Out-String).Trim()
+  - ps: Update-Vcpkg
   before_build:
   - cd %APPVEYOR_BUILD_FOLDER%
   build_script:
@@ -52,6 +53,7 @@ for:
   - pwsh: |
       Import-Module -Name .\AppVeyorHelpers.psd1
       Show-SystemInfo -Path -All
+      Update-Vcpkg
   - pwsh: Install-Module Pester -Force
   - pwsh: >-
       ( Get-Module Pester -ListAvailable |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,13 @@ skip_commits:
   - LICENSE
   - '**/*.md'
 
+cache:
+- 'C:\Users\appveyor\Tools\cache\vcpkg'
+
+environment:
+  global:
+    APPVEYOR_SAVE_CACHE_ON_ERROR: true
+
 image:
 - Visual Studio 2019
 - Visual Studio 2017

--- a/AppVeyor/AppVeyor.psd1
+++ b/AppVeyor/AppVeyor.psd1
@@ -1,7 +1,7 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = ''
-ModuleVersion = '0.1'
+ModuleVersion = '0.2'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/AppVeyor/Send-Message.Tests.ps1
+++ b/AppVeyor/Send-Message.Tests.ps1
@@ -269,6 +269,10 @@ Describe 'Send-Message' {
       Send-Message -Error -Message 'text' -ContinueOnError 6>&1 |
         Should -Be 'ERROR: text'
     }
+    It 'Details (channel 6 only) -ContinueOnError' {
+      Send-Message -Error -Message 'text' -Details 'more text' `
+        -ContinueOnError 6>&1 | Should -Be @('ERROR: text', 'more text')
+    }
   }
   Context 'Call to Add-AppveyorMessage' {
     # Enable output to Message console.

--- a/AppVeyor/Send-Message.Tests.ps1
+++ b/AppVeyor/Send-Message.Tests.ps1
@@ -225,6 +225,10 @@ Describe 'Send-Message' {
       Send-Message -Warning 'text' -Details 'more text' -HideDetails 3>&1 |
         Should -Be 'text'
     }
+    It 'Log Only' {
+      Send-Message -Warning 'text' -Details 'more text' -LogOnly 3>&1 |
+        Should -Be $null
+    }
     It 'NoNewLine' {
       Send-Message -Warning -Message 'text' -Details 'more text' 3>&1 |
         Should -Be "text`nmore text"
@@ -240,6 +244,10 @@ Describe 'Send-Message' {
     It 'piped Details, HideDetails' {
       'a','b','c' | Send-Message -Warning 'title' -HideDetails 3>&1 |
         Should -Be "title"
+    }
+    It 'piped Details, LogOnly' {
+      'a','b','c' | Send-Message -Warning 'title' -LogOnly 3>&1 |
+        Should -Be $null
     }
   }
   Context 'Error' {

--- a/AppVeyor/Send-Message.psd1
+++ b/AppVeyor/Send-Message.psd1
@@ -3,7 +3,7 @@
 #>
 @{
 RootModule = 'Send-Message.psm1'
-ModuleVersion = '0.3'
+ModuleVersion = '0.4'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/AppVeyor/Show-SystemInfo.Tests.ps1
+++ b/AppVeyor/Show-SystemInfo.Tests.ps1
@@ -160,6 +160,18 @@ Describe 'Internal Show-<software>Version' {
         Show-CurlVersion | Should -match '^([0-9]+\.)+[0-9]+$'
       }
     }
+    Context 'vcpkg' {
+      $available = $(Test-Command 'vcpkg version')
+      It 'no throw' {
+          { Show-VcpkgVersion } | Should -not -Throw
+      }
+      It 'return version number' {
+        if (-not $available) {
+          Set-ItResult -Inconclusive -Because ('no vcpkg')
+        }
+        Show-VcpkgVersion | Should -match '^([0-9]+\.)+[0-9]+'
+      }
+    }
     Context 'mock software unavailable' {
       Mock Test-Command { return $false } -ModuleName Show-SystemInfo
       It 'CMake' {
@@ -176,6 +188,9 @@ Describe 'Internal Show-<software>Version' {
       }
       It 'Curl' {
         Show-CurlVersion | Should -MatchExactly ' ?'
+      }
+      It 'vcpkg' {
+        Show-VcpkgVersion | Should -MatchExactly ' ?'
       }
     }
   }
@@ -208,6 +223,9 @@ Describe 'Show-SystemInfo' {
     }
     It 'no throw on -Curl' {
       { Show-SystemInfo -Curl } | Should -not -Throw
+    }
+    It 'no throw on -Vcpkg' {
+      { Show-SystemInfo -Vcpkg } | Should -not -Throw
     }
     It 'no throw on -All' {
       { Show-SystemInfo -All } | Should -not -Throw

--- a/AppVeyor/Show-SystemInfo.Tests.ps1
+++ b/AppVeyor/Show-SystemInfo.Tests.ps1
@@ -198,6 +198,9 @@ Describe 'Internal Show-<software>Version' {
 ##====--------------------------------------------------------------------====##
 
 Describe 'Show-SystemInfo' {
+  # Suppress output to the Appveyor Message API.
+  Mock Assert-CI { return $false } -ModuleName Send-Message
+
   It 'has documentation' {
     Get-Help Show-SystemInfo | Out-String |
       Should -MatchExactly 'SYNOPSIS' -Because $msg_documentation
@@ -205,6 +208,9 @@ Describe 'Show-SystemInfo' {
   Context 'Basic operation' {
     It 'no throw' {
       { Show-SystemInfo } | Should -not -Throw
+    }
+    It 'no throw on -Path' {
+      { Show-SystemInfo -Path } | Should -not -Throw
     }
     It 'no throw on -PowerShell' {
       { Show-SystemInfo -PowerShell } | Should -not -Throw

--- a/AppVeyor/Show-SystemInfo.psd1
+++ b/AppVeyor/Show-SystemInfo.psd1
@@ -6,7 +6,7 @@
 #>
 @{
 RootModule = 'Show-SystemInfo.psm1'
-ModuleVersion = '0.2'
+ModuleVersion = '0.3'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/AppVeyor/Show-SystemInfo.psd1
+++ b/AppVeyor/Show-SystemInfo.psd1
@@ -6,7 +6,7 @@
 #>
 @{
 RootModule = 'Show-SystemInfo.psm1'
-ModuleVersion = '0.3'
+ModuleVersion = '0.3.1'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'
@@ -46,7 +46,8 @@ PowerShellVersion = '5.1'
 # Modules that must be imported into the global environment prior to importing this module
 RequiredModules = @(
   @{ModuleName="${PSScriptRoot}\..\local\All.psd1"; ModuleVersion='0.2'},
-  @{ModuleName="${PSScriptRoot}\..\General\Test-Command.psd1"; ModuleVersion='0.3'}
+  @{ModuleName="${PSScriptRoot}\..\General\Test-Command.psd1"; ModuleVersion='0.3'},
+  @{ModuleName="${PSScriptRoot}\Send-Message.psd1"; ModuleVersion='0.4'}
 )
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 # NestedModules = @()

--- a/AppVeyor/Show-SystemInfo.psm1
+++ b/AppVeyor/Show-SystemInfo.psm1
@@ -50,6 +50,7 @@ function Show-SystemInfo {
     [Alias('ColumnWidth')]
     # Alignment of data/ first column width (default 20 characters).
     [Int]$Align = 20,
+    [Switch]$Path,
     [switch]$All,
     [switch]$CMake,
     [switch]$LLVM,
@@ -129,6 +130,8 @@ function Show-SystemInfo {
     if ($Python -or $All)   { $out += Join-Info Python $(Show-PythonVersion) }
     if ($Curl -or $All)     { $out += Join-Info Curl $(Show-CurlVersion) }
     if ($Vcpkg -or $All)    { $out += Join-Info vcpkg $(Show-VcpkgVersion) }
+
+    if ($Path) { Show-EnvPath }
   }
   Process
   {
@@ -176,6 +179,18 @@ function Join-Info {
   }
   if ($Name) { $Name = ($Name + ': ') }
   return ($( $Name.PadRight($Length,' ') ) + $Data)
+}
+##====--------------------------------------------------------------------====##
+
+function Show-EnvPath {
+  $UserPath = `
+    [Environment]::GetEnvironmentVariable('PATH', 'User') -replace ';',"`n"
+  $MachinePath = `
+    [Environment]::GetEnvironmentVariable('PATH', 'Machine') `
+    -replace ';',"`n"
+  Send-Message -Info 'Environment PATH' -Details (
+    'User PATH', $UserPath, ("`n"+'Machine PATH'), $MachinePath
+  ) -LogOnly
 }
 ##====--------------------------------------------------------------------====##
 

--- a/AppVeyor/Show-SystemInfo.psm1
+++ b/AppVeyor/Show-SystemInfo.psm1
@@ -56,7 +56,8 @@ function Show-SystemInfo {
     [switch]$PowerShell,
     [switch]$Python,
     [switch]$SevenZip,
-    [switch]$Curl
+    [switch]$Curl,
+    [switch]$Vcpkg
   )
   Begin
   {
@@ -127,6 +128,7 @@ function Show-SystemInfo {
     if ($CMake -or $All)    { $out += Join-Info CMake $(Show-CMakeVersion) }
     if ($Python -or $All)   { $out += Join-Info Python $(Show-PythonVersion) }
     if ($Curl -or $All)     { $out += Join-Info Curl $(Show-CurlVersion) }
+    if ($Vcpkg -or $All)    { $out += Join-Info vcpkg $(Show-VcpkgVersion) }
   }
   Process
   {
@@ -245,6 +247,21 @@ function Show-CurlVersion {
     return (
       $(curl.exe -V) -split ' ' |
         Select-String -Pattern '^([0-9]+\.)+[0-9]+.*'
+    )
+  } else { return ' ?' }
+}
+
+<#
+.SYNOPSIS
+  Acquire the version number from vcpkg.
+#>
+function Show-VcpkgVersion {
+  [OutputType([String])]
+  param()
+  if (Test-Command 'vcpkg version') {
+    return (
+      (vcpkg version | Select-String -Pattern 'version [0-9]') -split ' ' |
+        Select-String -Pattern '^[0-9].+'
     )
   } else { return ' ?' }
 }

--- a/AppVeyorHelpers.psd1
+++ b/AppVeyorHelpers.psd1
@@ -7,7 +7,7 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = ''
-ModuleVersion = '0.11.0'
+ModuleVersion = '0.11.1'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/AppVeyorHelpers.psd1
+++ b/AppVeyorHelpers.psd1
@@ -7,7 +7,7 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = ''
-ModuleVersion = '0.11.1'
+ModuleVersion = '0.12.0'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/C++/Install-Ninja.Tests.ps1
+++ b/C++/Install-Ninja.Tests.ps1
@@ -526,8 +526,17 @@ Describe 'Install-Ninja (online)' -Tag 'online' {
       It 'throw path info' {
         { Install-Ninja -Tag 'v1.8.2' -InstallDir "$InstallDir" `
           -AddToPath 3>$null 6>$null
-      } | Should -Throw 'Failed to find Ninja on the search path.'
+        } | Should -Throw 'Failed to find Ninja on the search path.'
       }
+      # Work-around issue with asynchronous files IO on Windows.
+      $capture = Join-Path 'TestDrive:\' '*'
+      while ($true) {
+        if ((Remove-Item $capture -Recurse -Force -ErrorAction Continue *>&1
+        ) -ne $null) {
+          Start-Sleep -Seconds 0.5
+        } else { break }
+      }
+      # /Work-around
     }
   }
   $env:Path = $original_path

--- a/C++/Update-Vcpkg.Tests.ps1
+++ b/C++/Update-Vcpkg.Tests.ps1
@@ -787,12 +787,22 @@ Describe 'Update-Vcpkg' {
       1>$null) 3>&1 | should -Match 'Update-Repository: vcpkg not installed'
       Test-Path (Join-Path $vcpkg_dir '*') | Should -Be $false
     }
+
+    # Work-around issue with asynchronous file IO on Windows.
+    $capture = Join-Path 'TestDrive:\' '*'
+    while ($true) {
+      if ((Remove-Item $capture -Recurse -Force -ErrorAction Continue *>&1
+      ) -ne $null) {
+        Start-Sleep -Seconds 0.5
+      } else { break }
+    }
+    # /Work-around
   }
   Context 'WhatIf & Latest; mock Location' {
     Mock Assert-CI { return $false } -ModuleName Update-Vcpkg
     Mock Select-VcpkgLocation { (Join-Path 'TestDrive:\' 'loc').ToString() } `
       -ModuleName Update-Vcpkg
-    New-Item -Path 'TestDrive:\' -Name 'loc' -ItemType Directory
+    $vcpkg_dir = New-Item -Path 'TestDrive:\' -Name 'loc' -ItemType Directory
 
     It 'no changes with -Latest -WhatIf' {
       if (-not (Test-Command 'vcpkg version')) {
@@ -804,6 +814,15 @@ Describe 'Update-Vcpkg' {
       Update-Vcpkg -Latest -Quiet -WhatIf 3>&1 |
         Should -Match 'Update-Repository: vcpkg not installed'
     }
+
+    # Work-around issue with asynchronous file IO on Windows.
+    while ($true) {
+      if ((Remove-Item $vcpkg_dir -Recurse -Force -ErrorAction Continue *>&1
+      ) -ne $null) {
+        Start-Sleep -Seconds 0.5
+      } else { break }
+    }
+    # /Work-around
   }
   Context 'WhatIf: build after retrieval from cache (mocked)' {
     Mock Update-Repository { return $null } -ModuleName Update-Vcpkg
@@ -837,6 +856,15 @@ Describe 'Update-Vcpkg' {
       Assert-MockCalled -CommandName Test-IfReleaseWithIssues `
         -ModuleName update-Vcpkg -Times 1 -Exactly -Scope It
     }
+
+    # Work-around issue with asynchronous file IO on Windows.
+    while ($true) {
+      if ((Remove-Item $vcpkg_dir -Recurse -Force -ErrorAction Continue *>&1
+      ) -ne $null) {
+        Start-Sleep -Seconds 0.5
+      } else { break }
+    }
+    # /Work-around
   }
 
   Context 'WhatIf: no cache needed' {
@@ -867,6 +895,16 @@ Describe 'Update-Vcpkg' {
       Assert-MockCalled -CommandName Remove-Item `
         -ModuleName update-Vcpkg -Times 1 -Exactly -Scope It
     }
+
+    # Work-around issue with asynchronous file IO on Windows.
+    while ($true) {
+      if ((Remove-Item $vcpkg_dir -Recurse -Force -ErrorAction Continue *>&1
+      ) -ne $null) {
+        Start-Sleep -Seconds 0.5
+      } else { break }
+    }
+    # /Work-around
   }
+
 } # /Describe 'Update-Vcpkg'
 ##====--------------------------------------------------------------------====##

--- a/C++/Update-Vcpkg.Tests.ps1
+++ b/C++/Update-Vcpkg.Tests.ps1
@@ -752,7 +752,7 @@ Describe 'Update-Vcpkg' {
           { Update-vcpkg -Path $path 6>$null } |
             Should -Throw 'not empty and not a git working directory'
           Assert-MockCalled -CommandName Assert-CI -ModuleName Send-Message `
-            -Scope It -Times 3 -Exactly
+            -Scope It -Times 2 -Exactly
         }
       }
     }

--- a/C++/Update-Vcpkg.Tests.ps1
+++ b/C++/Update-Vcpkg.Tests.ps1
@@ -5,6 +5,12 @@ Set-StrictMode -Version Latest
 ##====--------------------------------------------------------------------====##
 $global:msg_documentation = 'at least 1 empty line above documentation'
 
+if (Assert-CI) {
+  # Prevent warnings on AppVeyor.
+  git config --global user.name "BuildServer"
+  git config --global user.email "farwaykorse@example.com"
+}
+
 ##====--------------------------------------------------------------------====##
 Describe 'Internal Select-VcpkgLocation' {
   InModuleScope Update-Vcpkg {
@@ -187,7 +193,7 @@ Describe 'Internal Test-ChangedVcpkgSource' {
         'some text' > .\toolsrc\something.cpp 
         git add *
         git commit -m 'initial' --quiet
-      # no changes: do not create the .hash file.
+        # no changes: do not create the .hash file.
         It 'WhatIf' {
           if (Test-Path $hash_file -PathType Leaf) { Remove-Item $hash_file }
           { Test-ChangedVcpkgSource -WhatIf 3>$null } | Should -not -Throw

--- a/C++/Update-Vcpkg.Tests.ps1
+++ b/C++/Update-Vcpkg.Tests.ps1
@@ -742,7 +742,7 @@ Describe 'Update-Vcpkg' {
           { Update-vcpkg -Path $path 6>$null } |
             Should -Throw 'not empty and not a git working directory'
           Assert-MockCalled -CommandName Assert-CI -ModuleName Send-Message `
-            -Scope It -Times 2 -Exactly
+            -Scope It -Times 3 -Exactly
         }
       }
     }

--- a/C++/Update-Vcpkg.Tests.ps1
+++ b/C++/Update-Vcpkg.Tests.ps1
@@ -348,12 +348,15 @@ Describe 'Internal Import-CachedVcpkg' {
         Should -Match '-WhatIf.*-Confirm'
     }
 
-    Context '$cached_dir not defined' {
+    It '$cached_dir or $Location not defined' {
       Mock Assert-CI { return $true } -ModuleName 'Update-Vcpkg'
 
-      It 'should throw' {
-        { Import-CachedVcpkg 2>$null } | Should -Throw
-      }
+      { Import-CachedVcpkg 2>$null } | Should -Throw
+      $cached_dir = 'TestDrive:\'
+      { Import-CachedVcpkg 2>$null } | Should -Throw
+      $cached_dir = ''
+      $Location = 'TestDrive:\'
+      { Import-CachedVcpkg 2>$null } | Should -Throw
     }
 
     Context 'WhatIf' {
@@ -364,6 +367,7 @@ Describe 'Internal Import-CachedVcpkg' {
       New-Item -Path $cache_dir -ItemType Directory
       function Invoke-Import {
         $cache_dir = 'TestDrive:\cache'
+        $Location = 'TestDrive:\target'
         return (Import-CachedVcpkg -WhatIf)
       }
       In -Path $target_dir {
@@ -393,6 +397,7 @@ Describe 'Internal Import-CachedVcpkg' {
       New-Item -Path $target_dir -ItemType Directory
       function Invoke-Import {
         $cache_dir = 'TestDrive:\cache 1'
+        $Location = 'TestDrive:\target 1'
         return Import-CachedVcpkg
       }
       In -Path $target_dir {

--- a/C++/Update-Vcpkg.Tests.ps1
+++ b/C++/Update-Vcpkg.Tests.ps1
@@ -1,0 +1,866 @@
+Import-Module -Name "${PSScriptRoot}\Update-Vcpkg.psd1" -Force
+
+Set-StrictMode -Version Latest
+
+##====--------------------------------------------------------------------====##
+$global:msg_documentation = 'at least 1 empty line above documentation'
+
+##====--------------------------------------------------------------------====##
+Describe 'Internal Select-VcpkgLocation' {
+  InModuleScope Update-Vcpkg {
+    It 'has documentation' {
+      Get-Help Select-VcpkgLocation | Out-String |
+        Should -MatchExactly 'SYNOPSIS' -Because $msg_documentation
+    }
+    It 'supports -WhatIf and -Confirm' {
+      Get-Command -Name Select-VcpkgLocation -Syntax |
+        Should -Match '-Whatif.*-Confirm'
+    }
+
+    Context 'find from executable' {
+      Mock Assert-CI { return $true } -ModuleName Update-Vcpkg
+      Mock Test-Path { return $true } -ModuleName Update-Vcpkg
+      if ($env:CI_WINDOWS -ne 'true') {
+        $changed = $true; $env:CI_WINDOWS = 'true'
+      } else { $changed = $false }
+      It 'default location (Windows)' {
+          { Select-VcpkgLocation } | Should -not -Throw
+        Select-VcpkgLocation | Should -Be 'C:\Tools\vcpkg'
+      }
+      if ($changed) {
+       $changed = $null; $env:CI_WINDOWS = 'false'
+      }
+    }
+    Context 'find from executable' {
+      Mock Assert-CI { return $false } -ModuleName Update-Vcpkg
+
+      It 'find vcpkg' {
+        if (-not (Test-Command 'vcpkg version')) {
+          Set-ItResult -Skipped -Because 'vcpkg not on path'
+        }
+        { Select-VcpkgLocation } | Should -not -Throw
+        $Location = Select-VcpkgLocation
+        Test-Path $Location -PathType Container | Should -Be $true
+        ( (Test-Path (Join-Path $Location 'vcpkg.exe') -PathType Leaf) -or
+          (Test-Path (Join-Path $Location 'vcpkg') -PathType Leaf)
+        ) | Should -Be $true
+        In $Location {
+          Test-Command 'git status' | Should -Be $true `
+            -Because 'expect a git working directory'
+        }
+      }
+
+    }
+    Context 'fallback location' {
+      Mock Assert-CI { return $false } -ModuleName Update-Vcpkg
+      Mock Test-Command { return $false } -ModuleName Update-Vcpkg
+      $tools_dir = Join-Path $HOME 'Tools'
+      $expected = Join-Path $tools_dir 'vcpkg'
+      if (-not (Test-Path -Path (Join-Path $expected '*')) ) {
+        $empty = $true
+        if (Test-Path -Path $expected) { Remove-Item $expected }
+        if ( (Test-Path -Path $tools_dir -PathType Container) -and
+          -not (Test-Path -Path (Join-Path $tools_dir '*'))
+        ) {
+          Remove-Item $tools_dir
+        }
+      } else {
+        $empty = $false
+      }
+      It 'WhatIf' {
+        { Select-VcpkgLocation -WhatIf } | Should -not -Throw
+        Select-VcpkgLocation -WhatIf | Should -Be $expected
+        if ($empty) {
+          Test-Path -Path $expected -PathType Container | Should -Be $false
+        }
+      }
+      It 'create directory' {
+        { Select-VcpkgLocation } | Should -not -Throw
+        Select-VcpkgLocation | Should -Be $expected
+        Test-Path -Path $tools_dir -PathType Container | Should -Be $true
+        Test-Path -Path $expected -PathType Container | Should -Be $true
+      }
+      if ($empty) {
+        if (Test-Path -Path $expected) { Remove-Item $expected }
+        if ( (Test-Path -Path $tools_dir -PathType Container) -and
+          -not (Test-Path -Path (Join-Path $tools_dir '*'))
+        ) {
+          Remove-Item $tools_dir
+        }
+      }
+    }
+  }
+}
+
+##====--------------------------------------------------------------------====##
+Describe 'Internal Test-IfReleaseWithIssues' {
+  InModuleScope Update-Vcpkg {
+    # Suppress output to the Appveyor Message API.
+    Mock Assert-CI { return $false } -ModuleName Send-Message
+
+    It 'has documentation' {
+      Get-Help Test-IfReleaseWithIssues | Out-String |
+        Should -MatchExactly 'SYNOPSIS' -Because $msg_documentation
+    }
+    It 'no support for -WhatIf and -Confirm' {
+      Get-Command -Name Test-IfReleaseWithIssues -Syntax |
+        Should -not -Match '-Whatif.*-Confirm'
+    }
+
+    Context 'mock calling vcpkg' {
+      In -Path 'TestDrive:\' {
+        '"version 2019.02.11"' > vcpkg.ps1
+        It 'no throw' {
+          { Test-IfReleaseWithIssues } | Should -not -Throw
+          Assert-MockCalled Assert-CI -ModuleName Send-Message -Times 0 `
+            -Exactly -Scope It
+        }
+        ( 'Write-Output "Vcpkg package management program version ' +
+          '2019.06.26-nohash' + '`n`nSee LICENSE.txt for license information."'
+        ) > vcpkg.ps1
+        It 'no issue' {
+          { Test-IfReleaseWithIssues } | Should -not -Throw
+          Test-IfReleaseWithIssues | Should -Be $false
+          Assert-MockCalled Assert-CI -ModuleName Send-Message -Times 0 `
+            -Exactly -Scope It
+        }
+        ( 'Write-Output "Vcpkg package management program version ' +
+          '0.0.113' + '`n`nSee LICENSE.txt for license information."'
+        ) > vcpkg.ps1
+        It 'version 0.0.113' {
+          { Test-IfReleaseWithIssues 3>$null } | Should -not -Throw
+          Test-IfReleaseWithIssues 3>$null | Should -Be $true
+          Assert-MockCalled Assert-CI -ModuleName Send-Message -Times 2 `
+            -Exactly -Scope It
+        }
+        ( 'Write-Output "Vcpkg package management program version ' +
+          '2018.11.23-nohash' + '`n`nSee LICENSE.txt for license information."'
+        ) > vcpkg.ps1
+        It 'version 2018.11.23-nohash' {
+          Test-IfReleaseWithIssues 3>$null | Should -Be $true
+          Assert-MockCalled Assert-CI -ModuleName Send-Message -Times 1 `
+            -Exactly -Scope It
+        }
+        It 'warning output' {
+          (Test-IfReleaseWithIssues 1>$null) 3>&1 |
+            Should -Match 'This vcpkg release has known issues. Rebuilding'
+        }
+      }
+    }
+  }
+}
+
+##====--------------------------------------------------------------------====##
+Describe 'Internal Test-ChangedVcpkgSource' {
+  InModuleScope Update-Vcpkg {
+    # Suppress output to the Appveyor Message API.
+    Mock Assert-CI { return $false } -ModuleName Send-Message
+
+    It 'has documentation' {
+      Get-Help Test-ChangedVcpkgSource | Out-String |
+        Should -MatchExactly 'SYNOPSIS' -Because $msg_documentation
+      Get-Help Test-ChangedVcpkgSource -Full | Out-String |
+        Should -MatchExactly 'OUTPUTS' -Because $msg_documentation
+    }
+    It 'supports -WhatIf and -Confirm' {
+      Get-Command -Name Test-ChangedVcpkgSource -Syntax |
+        Should -Match '-Whatif.*-Confirm'
+    }
+
+    Context 'WhatIf' {
+      $hash_file = Join-Path $PSScriptRoot 'vcpkg_source.hash'
+      New-Item 'TestDrive:\' -Name 'dir1' -ItemType Directory
+
+      In -Path 'TestDrive:\dir1' {
+        It 'not in a git working directory' {
+          { Test-ChangedVcpkgSource -WhatIf } | Should -not -Throw
+          Test-ChangedVcpkgSource -WhatIf | Should -Be $true
+        }
+      }
+      In -Path 'TestDrive:\dir1' {
+        # Set up test environment.
+        git init --quiet
+        ( 'Write-Output "Vcpkg package management program version ' +
+          '2019.06.26-nohash' + '`n`nSee LICENSE.txt for license information."'
+        ) > vcpkg.ps1
+        New-Item .\toolsrc -ItemType Directory
+        'some text' > .\toolsrc\something.cpp 
+        git add *
+        git commit -m 'initial' --quiet
+      # no changes: do not create the .hash file.
+        It 'WhatIf' {
+          if (Test-Path $hash_file -PathType Leaf) { Remove-Item $hash_file }
+          { Test-ChangedVcpkgSource -WhatIf 3>$null } | Should -not -Throw
+          Assert-MockCalled Assert-CI -ModuleName Send-Message -Times 1 `
+            -Exactly -Scope It
+        }
+        It 'no vcpkg_source.hash file created' {
+          Test-Path $hash_file -PathType Leaf | Should -Be $false
+        }
+        It 'should still return correctly $true or $false' {
+          Test-ChangedVcpkgSource -WhatIf 3>$null | Should -Be $true
+          # Create the hash-file.
+          Test-ChangedVcpkgSource 3>$null
+          Test-ChangedVcpkgSource -WhatIf | Should -Be $false
+        }
+      }
+      if (Test-Path $hash_file -PathType Leaf) { Remove-Item $hash_file }
+    }
+
+    Context 'Test Run' {
+      $hash_file = Join-Path $PSScriptRoot 'vcpkg_source.hash'
+      New-Item 'TestDrive:\' -Name 'dir 2' -ItemType Directory
+
+      In -Path 'TestDrive:\dir 2' {
+        It 'throws when not in a Git working directory' {
+          { Test-ChangedVcpkgSource } |
+            Should -Throw 'not a git working directory'
+        }
+        # Set up test environment.
+        git init --quiet
+        ( 'Write-Output "Vcpkg package management program version ' +
+          '2019.06.26-nohash' + '`n`nSee LICENSE.txt for license information."'
+        ) > vcpkg.ps1
+        New-Item .\toolsrc -ItemType Directory
+        'some text' > .\toolsrc\something.cpp 
+        git add *
+        git commit -m 'initial' --quiet
+        # Verify operation.
+        It 'no vcpkg_source.hash' {
+          Test-Path (Join-Path $PSScriptRoot 'Update-Vcpkg.psm1') `
+            -PathType Leaf | Should -Be $true
+          if (Test-Path $hash_file -PathType Leaf) { Remove-Item $hash_file }
+          Test-Path $hash_file -PathType Leaf | Should -Be $false
+        }
+        It 'no throw' {
+          { Test-ChangedVcpkgSource 3>$null } | Should -not -Throw `
+            -Because 'initial commit'
+          { Test-ChangedVcpkgSource 3>$null } | Should -not -Throw `
+            -Because 'no change'
+        }
+        Remove-Item $hash_file
+        It 'only initial commit displays a warning' {
+          (Test-ChangedVcpkgSource 1>$null) 3>&1 |
+            Should -Match 'No Cache Found' -Because 'initial commit'
+          (Test-ChangedVcpkgSource 1>$null) 3>&1 | Should -Be $null `
+            -Because 'no change'
+          Assert-MockCalled Assert-CI -ModuleName Send-Message -Times 1 `
+            -Exactly -Scope It
+        }
+        Remove-Item $hash_file
+        It 'initial commit returns $true' {
+          Test-ChangedVcpkgSource 3>$null | Should -Be $true
+        }
+        It 'no change returns $false' {
+          Test-ChangedVcpkgSource | Should -Be $false -Because 'no change'
+        }
+        It 'created vcpkg_source.hash, with a SHA1 hash' {
+          Test-Path $hash_file -PathType Leaf | Should -Be $true
+          Get-Content $hash_file | Should -Match '[0-9A-F]{40}' `
+            -Because 'SHA1 hash'
+        }
+        # Modify test environment.
+        'other things' > .\toolsrc\others.cpp
+        git add *
+        git commit -m 'other things' --quiet
+        # Verify operation.
+        It 'change to source returns $true' {
+          try { Test-ChangedVcpkgSource 3>&1 | Should -Be $true }
+          catch { throw $_ | Should -not -Throw }
+        }
+        # Modify test environment.
+        'add more' >> .\toolsrc\others.cpp
+        git add *
+        git commit --amend -m 'more' --quiet
+        # Verify operation.
+        It 'no warning after change to source with vcpkg_source.hash present' {
+          (Test-ChangedVcpkgSource 1>$null) 3>&1 | Should -Be $null
+        }
+      }
+      Remove-Item $hash_file
+    }
+    Context '$cache_dir defined' {
+      $hash_file = Join-Path $PSScriptRoot 'vcpkg_source.hash'
+      $cache_dir = Join-Path 'TestDrive:\' 'cache'
+      $cached_file = Join-Path $cache_dir 'vcpkg_source.hash'
+
+      # Helper function
+      function Invoke-Test {
+        $cache_dir = Join-Path 'TestDrive:\' 'cache'
+        Test-ChangedVcpkgSource
+      }
+      $working_dir = New-Item 'TestDrive:\' -Name 'dir 3' -ItemType Directory
+
+      In -Path $working_dir {
+        # Set up test environment.
+        git init --quiet
+        ( 'Write-Output "Vcpkg package management program version ' +
+          '2019.06.26-nohash' + '`n`nSee LICENSE.txt for license information."'
+        ) > vcpkg.ps1
+        New-Item .\toolsrc -ItemType Directory
+        'some text' > .\toolsrc\something.cpp 
+        git add *
+        git commit -m 'initial' --quiet
+        It 'initial run - create vcpkg_source.hash' {
+          { Invoke-Test 3>$null } | Should -not -Throw
+          Test-Path $hash_file -PathType Leaf | Should -Be $true
+          Test-Path $cache_dir -PathType Container | Should -Be $false
+        }
+        It 'use local when $cache_dir not exists' {
+          Invoke-Test | Should -Be $false
+          Test-Path $hash_file -PathType Leaf | Should -Be $true
+          Test-Path $cache_dir -PathType Container | Should -Be $false
+        }
+        New-Item $cache_dir -ItemType Directory -Force
+        It 'move to $cache_dir when both exist' {
+          Test-Path $hash_file -PathType Leaf | Should -Be $true
+          Invoke-Test | Should -Be $false
+          Test-Path $cache_dir -PathType Container | Should -Be $true
+          Test-Path $hash_file -PathType Leaf | Should -Be $false
+        }
+      } # In
+    } # Context $cache_dir defined
+  } # InModuleScope Update-Vcpkg
+} # Describe Internal Test-ChangedVcpkgSource
+
+##====--------------------------------------------------------------------====##
+Describe 'Internal Import-CachedVcpkg' {
+  InModuleScope Update-Vcpkg {
+    It 'has documentation' {
+      Get-Help Import-CachedVcpkg | Out-String |
+        Should -MatchExactly 'SYNOPSIS' -Because $msg_documentation
+      Get-Help Import-CachedVcpkg -Full | Out-String |
+        Should -MatchExactly 'OUTPUTS' -Because $msg_documentation
+    }
+    It 'supports -WhatIf and -Confirm' {
+      Get-Command -Name Import-CachedVcpkg -Syntax |
+        Should -Match '-Whatif.*-Confirm'
+    }
+
+    Context '$cached_dir not defined' {
+      Mock Assert-CI { return $true } -ModuleName 'Update-Vcpkg'
+
+      It 'should throw' {
+        { Import-CachedVcpkg 2>$null } | Should -Throw
+      }
+    }
+
+    Context 'WhatIf' {
+      Mock Assert-CI { return $true } -ModuleName 'Update-Vcpkg'
+      $cache_dir = 'TestDrive:\cache'
+      $target_dir = 'TestDrive:\target'
+      New-Item -Path $target_dir -ItemType Directory
+      New-Item -Path $cache_dir -ItemType Directory
+      function Invoke-Import {
+        $cache_dir = 'TestDrive:\cache'
+        return (Import-CachedVcpkg -WhatIf)
+      }
+      In -Path $target_dir {
+        Remove-Item -Path $cache_dir/* -Force
+        Remove-Item -Path ./* -Force
+
+        It 'do not copy file (vcpkg)' {
+          New-Item -Path $cache_dir -Name 'vcpkg' -ItemType File
+          Test-Path 'vcpkg' -PathType Leaf | Should -Be $false
+          { Invoke-Import } | Should -not -Throw
+          Test-Path 'vcpkg' -PathType Leaf | Should -Be $false
+        }
+        It 'do not copy file (vcpkg.exe)' {
+          Remove-Item -Path $cache_dir/* -Force
+          Remove-Item -Path ./* -Force
+          New-Item -Path $cache_dir -Name 'vcpkg.exe' -ItemType File
+          { Invoke-Import } | Should -not -Throw
+          Test-Path 'vcpkg.exe' -PathType Leaf | Should -Be $false
+        }
+      }
+    }
+
+    Context '$cache_dir defined' {
+      Mock Assert-CI { return $true } -ModuleName 'Update-Vcpkg'
+      $cache_dir = 'TestDrive:\cache 1'
+      $target_dir = 'TestDrive:\target 1'
+      New-Item -Path $target_dir -ItemType Directory
+      function Invoke-Import {
+        $cache_dir = 'TestDrive:\cache 1'
+        return Import-CachedVcpkg
+      }
+      In -Path $target_dir {
+        It 'non-existing directory' {
+          { Invoke-Import } | Should -not -Throw
+          Invoke-Import | Should -Be $false
+        }
+        It 'empty existing directory' {
+          New-Item -Path $cache_dir -ItemType Directory
+          { Invoke-Import } | Should -not -Throw
+          Invoke-Import | Should -Be $false
+        }
+        It 'copy vcpkg' {
+          New-Item -Path $cache_dir -Name 'vcpkg' -ItemType File
+          Test-Path 'vcpkg' -PathType Leaf | Should -Be $false
+          { Invoke-Import } | Should -not -Throw
+          Test-Path 'vcpkg' -PathType Leaf | Should -Be $true
+        }
+        It 'overwrite file in target directory' {
+          $old_size = (Get-Item (Join-Path $target_dir 'vcpkg')).Length
+          'some text' >> (Join-Path $cache_dir 'vcpkg')
+          { Invoke-Import } | Should -not -Throw
+          (Get-Item (Join-Path $target_dir 'vcpkg')).Length |
+            Should -not -Be $old_size
+        }
+        It 'copy vcpkg.exe' {
+          Remove-Item -Path $cache_dir/* -Force
+          Remove-Item -Path ./* -Force
+          New-Item -Path $cache_dir -Name 'vcpkg.exe' -ItemType File
+          Test-Path 'vcpkg' -PathType Leaf | Should -Be $false
+          Test-Path 'vcpkg.exe' -PathType Leaf | Should -Be $false
+          { Invoke-Import } | Should -not -Throw
+          Test-Path 'vcpkg.exe' -PathType Leaf | Should -Be $true
+        }
+        It 'do not copy vcpkg.txt' {
+          Remove-Item -Path $cache_dir/* -Force
+          Remove-Item -Path ./* -Force
+          New-Item -Path $cache_dir -Name 'vcpkg.txt' -ItemType File
+          { Invoke-Import } | Should -not -Throw
+          Test-Path 'vcpkg.txt' -PathType Leaf | Should -Be $false
+          Test-Path 'vcpkg' -PathType Leaf | Should -Be $false
+          Test-Path 'vcpkg.exe' -PathType Leaf | Should -Be $false
+        }
+        It 'do not copy from subdirectories' {
+          Remove-Item -Path $cache_dir/* -Force
+          Remove-Item -Path ./* -Force
+          New-Item -Path $cache_dir -Name 'dir'-ItemType Directory
+          New-Item -Path (Join-Path $cache_dir 'dir') -Name 'vcpkg.exe' `
+            -ItemType File
+          { Invoke-Import } | Should -not -Throw
+          Test-Path 'vcpkg.exe' -PathType Leaf | Should -Be $false
+          Test-Path 'dir' -PathType Container | Should -Be $false
+        }
+        It 'multiple files matching "vcpkg*"' {
+          New-Item -Path $cache_dir -Name 'vcpkg' -ItemType File -Force
+          New-Item -Path $cache_dir -Name 'vcpkg.exe' -ItemType File -Force
+          Remove-Item -Path * -Recurse -Force
+          { Invoke-Import } | Should -not -Throw
+          
+          Test-Path 'vcpkg' -PathType Leaf | Should -Be $true
+          Test-Path 'vcpkg.exe' -PathType Leaf | Should -Be $true
+        }
+        It 'not a directory (no throw)' {
+          Remove-Item -Path $cache_dir -Recurse -Force
+          Remove-Item -Path * -Force
+          New-Item -Path $cache_dir -ItemType File
+          { Invoke-Import } | Should -not -Throw
+          Invoke-Import | Should -Be $false
+          Test-Path 'vcpkg' -PathType Leaf | Should -Be $false
+        }
+        It 'not a file' {
+          Remove-Item -Path $cache_dir
+          New-Item -Path $cache_dir -ItemType Directory
+          New-Item -Path $cache_dir -Name 'vcpkg' -ItemType Directory
+          { Invoke-Import } | Should -not -Throw
+          Invoke-Import | Should -Be $false
+          Test-Path 'vcpkg' | Should -Be $false
+        }
+        It 'a folder and a file' {
+          New-Item -Path $cache_dir -Name 'vcpkg.exe' -ItemType File
+          { Invoke-Import } | Should -not -Throw
+          Test-Path 'vcpkg.exe' -PathType Leaf | Should -Be $true
+          Test-Path 'vcpkg' | Should -Be $true
+        }
+      }
+    }
+  }
+}
+
+##====--------------------------------------------------------------------====##
+Describe 'Internal Export-CachedVcpkg' {
+  InModuleScope Update-Vcpkg {
+    It 'has documentation' {
+      Get-Help Export-CachedVcpkg | Out-String |
+        Should -MatchExactly 'SYNOPSIS' -Because $msg_documentation
+    }
+    It 'supports -WhatIf and -Confirm' {
+      Get-Command -Name Export-CachedVcpkg -Syntax |
+        Should -Match '-Whatif.*-Confirm'
+    }
+
+    Context '$cache_dir not defined' {
+      Mock Assert-CI { return $true } -ModuleName 'Update-Vcpkg'
+
+      It 'should throw' {
+        { Export-CachedVcpkg 2>$null } | Should -Throw
+      }
+    }
+
+    Context 'WhatIf' {
+      Mock Assert-CI { return $true } -ModuleName 'Update-Vcpkg'
+      $cache_dir = 'TestDrive:\cache'
+      $vcpkg_dir = 'TestDrive:\vcpkg'
+      New-Item -Path $vcpkg_dir -ItemType Directory
+      New-Item -Path $cache_dir -ItemType Directory
+      function Invoke-Export {
+        $cache_dir = 'TestDrive:\cache'
+        return (Export-CachedVcpkg -WhatIf)
+      }
+      In -Path $vcpkg_dir {
+        Remove-Item -Path $cache_dir/* -Force
+        Remove-Item -Path ./* -Force
+
+        It 'do not copy file (vcpkg)' {
+          New-Item -Name 'vcpkg' -ItemType File
+          { Invoke-Export } | Should -not -Throw
+          Test-Path (Join-Path $cache_dir 'vcpkg') -PathType Leaf |
+            Should -Be $false
+        }
+        It 'do not copy file (vcpkg.exe)' {
+          Remove-Item -Path $cache_dir/* -Force
+          Remove-Item -Path ./* -Force
+          New-Item -Name 'vcpkg.exe' -ItemType File
+          { Invoke-Export } | Should -not -Throw
+          Test-Path (Join-Path $cache_dir 'vcpkg.exe') -PathType Leaf |
+            Should -Be $false
+        }
+      }
+    }
+
+    Context '$cache_dir defined' {
+      Mock Assert-CI { return $true } -ModuleName 'Update-Vcpkg'
+      $cache_dir = 'TestDrive:\cache 1'
+      $vcpkg_dir = 'TestDrive:\vcpkg dir'
+      New-Item -Path $vcpkg_dir -ItemType Directory
+      function Invoke-Export {
+        $cache_dir = 'TestDrive:\cache 1'
+        return Export-CachedVcpkg
+      }
+      $file_vcpkg = Join-Path $cache_dir 'vcpkg'
+      $file_exe = Join-Path $cache_dir 'vcpkg.exe'
+
+      In -Path $vcpkg_dir {
+        Remove-Item -Path ./* -Force
+        It 'no files to cache' {
+          { Invoke-Export } | Should -not -Throw
+          Test-Path $file_exe | Should -Be $false
+          Test-Path $file_vcpkg | Should -Be $false
+        }
+        It 'copy vcpkg' {
+          New-Item -Name 'vcpkg' -ItemType File
+          Test-Path $file_vcpkg -PathType Leaf | Should -Be $false
+          { Invoke-Export } | Should -not -Throw
+          Test-Path $file_vcpkg -PathType Leaf | Should -Be $true
+        }
+        It 'overwrite file in cache directory' {
+          $old_size = (Get-Item $file_vcpkg).Length
+          'some text' >> ./vcpkg
+          { Invoke-Export } | Should -not -Throw
+          (Get-Item $file_vcpkg).Length | Should -not -Be $old_size
+        }
+        It 'copy vcpkg.exe' {
+          Remove-Item -Path $cache_dir/* -Force
+          Remove-Item -Path ./* -Force
+          New-Item -Name 'vcpkg.exe' -ItemType File
+          Test-Path $file_vcpkg | Should -Be $false
+          Test-Path $file_exe -PathType Leaf | Should -Be $false
+          { Invoke-Export } | Should -not -Throw
+          Test-Path $file_exe -PathType Leaf | Should -Be $true
+        }
+        It 'do not copy vcpkg.txt' {
+          Remove-Item -Path $cache_dir/* -Force
+          Remove-Item -Path ./* -Force
+          New-Item -Path $vcpkg_dir -Name 'vcpkg.txt' -ItemType File
+          { Invoke-Export } | Should -not -Throw
+          Test-Path (Join-Path $cache_dir 'vcpkg.txt') -PathType Leaf |
+            Should -Be $false
+          Test-Path $file_vcpkg | Should -Be $false
+          Test-Path $file_exe -PathType Leaf | Should -Be $false
+        }
+        It 'do not copy from subdirectories' {
+          Remove-Item -Path $cache_dir/* -Force
+          Remove-Item -Path ./* -Force
+          New-Item -Name 'dir'-ItemType Directory
+          New-Item -Path (Join-Path $vcpkg_dir 'dir') -Name 'vcpkg.exe' `
+            -ItemType File
+          { Invoke-Export } | Should -not -Throw
+          Test-Path $file_exe | Should -Be $false
+          Test-Path (Join-Path $cache_dir 'dir') -PathType Container |
+            Should -Be $false
+        }
+        It 'multiple files matching "vcpkg(\.exe)?"' {
+          Remove-Item -Path $cache_dir/* -Recurse -Force
+          Remove-Item -Path ./* -Recurse -Force
+          New-Item -Name 'vcpkg' -ItemType File -Force
+          New-Item -Name 'vcpkg.exe' -ItemType File -Force
+          { Invoke-Export } | Should -not -Throw
+          Test-Path $file_vcpkg -PathType Leaf | Should -Be $true
+          Test-Path $file_exe -PathType Leaf | Should -Be $true
+        }
+      }
+    }
+  }
+}
+
+##====--------------------------------------------------------------------====##
+Describe 'Internal Update-Repository' {
+  InModuleScope Update-Vcpkg {
+    # Suppress output to the Appveyor Message API.
+    Mock Assert-CI { return $false } -ModuleName Send-Message
+
+    It 'has documentation' {
+      Get-Help Update-Repository | Out-String |
+        Should -MatchExactly 'SYNOPSIS' -Because $msg_documentation
+    }
+    It 'supports -WhatIf and -Confirm' {
+      Get-Command -Name Update-Repository -Syntax |
+        Should -Match '-Whatif.*-Confirm'
+    }
+
+    Context 'Input Validation' {
+    }
+    Context 'WhatIf' {
+      $dir = New-Item 'TestDrive:\dir0' -ItemType Directory
+      In -Path $dir {
+        It 'empty folder: clone & warning' {
+          { Update-Repository -WhatIf 3>$null } | Should -not -Throw
+          Update-Repository -WhatIf 3>&1 |
+            Should -Match 'vcpkg not installed in the expected location'
+        }
+      }
+      $dir = New-Item 'TestDrive:\dir1' -ItemType Directory
+      In -Path $dir {
+        New-Item -Name 'file' -ItemType File
+        It 'throw on non-empty directory without git' {
+          { Update-Repository -WhatIf 6>$null } |
+            Should -Throw 'not empty and not a git working directory'
+        }
+        git init
+        It 'throw on non-empty git directory without remote' {
+          { Update-Repository -WhatIf 6>$null } |
+            Should -Throw 'no remote repositories defined'
+        }
+      }
+      $dir = New-Item 'TestDrive:\dir2' -ItemType Directory
+      In -Path $dir {
+        git clone https://github.com/Farwaykorse/AppVeyorHelpers.git --quiet .\
+        It 'fetch & merge' {
+          { Update-Repository -WhatIf } | Should -not -Throw
+        }
+        It 'specific commit: checkout' {
+          { Update-Repository -WhatIf `
+            -Commit 64dd542dd02994e6925c5abf4b4b7618acfcfbb5
+          } | Should -not -Throw
+        }
+        It '-Verbose' {
+          { Update-Repository -Verbose -WhatIf } | Should -not -Throw
+        }
+      }
+    }
+    Context 'normal operation' {
+      $dir = New-Item 'TestDrive:\dir2' -ItemType Directory
+      In -Path $dir {
+        It 'clone & merge' {
+          { Update-Repository } | Should -not -Throw
+        }
+        It 'fetch & checkout' {
+          { Update-Repository -Commit ea9d29c05b110f203184eb4602b23325557de9c3 `
+            3>$null } | Should -not -Throw
+        }
+      }
+    }
+  }
+}
+
+##====--------------------------------------------------------------------====##
+Describe 'Update-Vcpkg' {
+  # Suppress output to the Appveyor Message API.
+  Mock Assert-CI { return $false } -ModuleName Send-Message
+
+  It 'has documentation' {
+    Get-Help Update-Vcpkg | Out-String |
+      Should -MatchExactly 'SYNOPSIS' -Because $msg_documentation
+  }
+  It 'supports -WhatIf and -Confirm' {
+    Get-Command -Name Update-Vcpkg -Syntax |
+      Should -Match '-Whatif.*-Confirm'
+  }
+
+  Context 'Input Validation' {
+    It 'throws on empty -FixedCommit' {
+      { Update-Vcpkg -FixedCommit } | Should -Throw 'missing an argument'
+    }
+    It 'throws on empty string -FixedCommit' {
+      { Update-Vcpkg -FixedCommit '' } |
+        Should -Throw 'argument is null or empty'
+    }
+    It 'throws on $null -FixedCommit' {
+      { Update-Vcpkg -FixedCommit $null } |
+        Should -Throw 'argument is null or empty'
+    }
+    It 'throws when -FixedCommit length is not 40 characters' {
+      { Update-Vcpkg -FixedCommit '123456789' } |
+        Should -Throw 'does not match'
+    }
+    It 'throws when -FixedCommit contains invalid characters' {
+      { Update-Vcpkg -FixedCommit 'CF83E1357XXXXXXDF1542850D66D8007D620E405'} |
+        Should -Throw 'does not match'
+    }
+    It 'throws on empty -Path' {
+      { Update-Vcpkg -Path } | Should -Throw 'missing an argument'
+    }
+    It 'throws on empty string -Path' {
+      { Update-Vcpkg -Path '' } | Should -Throw 'argument is null or empty'
+    }
+    It 'throws on $null -Path' {
+      { Update-Vcpkg -Path $null } | Should -Throw 'argument is null or empty'
+    }
+    It 'throws when -Path points to a file' {
+      New-Item -Path TestDrive:\ -Name file.txt -ItemType File
+      { Update-Vcpkg -Path 'TestDrive:\file.txt' } |
+        Should -Throw 'validation script'
+    }
+    Context 'Input Validation: -Path' {
+      Mock Select-VcpkgLocation { throw 'unexpected' } -ModuleName Update-Vcpkg
+      In -Path 'TestDrive:\' {
+        It 'invalid path' {
+#          { Update-vcpkg -Path '/../..' } | Should -Throw 'validation script'
+          { Update-vcpkg -Path './*' } | Should -Throw 'validation script'
+          { Update-vcpkg -Path './?' } | Should -Throw 'validation script'
+        }
+        $path = 'TestDrive:\path'
+        New-Item -Path $path -ItemType File
+        It 'throw: -Path is an existing file' {
+          { Update-vcpkg -Path $path } | Should -Throw 'validation script'
+        }
+        Remove-Item $path
+        $path = 'TestDrive:\path'
+        New-Item -Path $path -ItemType Directory
+        New-Item -Path $path -Name 'somefile.txt' -ItemType File
+        It 'throw: non-empty, not a git working directory' {
+          { Update-vcpkg -Path $path 6>$null } |
+            Should -Throw 'not empty and not a git working directory'
+          Assert-MockCalled -CommandName Assert-CI -ModuleName Send-Message `
+            -Scope It -Times 2 -Exactly
+        }
+      }
+    }
+  } # /Context: Input Validation
+  Context 'WhatIf & Path' {
+    Mock Add-EnvironmentPath { return $null } -ModuleName Update-Vcpkg
+    Mock Assert-CI { return $false } -ModuleName Update-Vcpkg
+    Mock Select-VcpkgLocation { throw 'unexpected' } -ModuleName Update-Vcpkg
+
+    # clone / merge
+    $vcpkg_dir = New-Item -Path 'TestDrive:\' -Name 'vc 1' -ItemType Directory
+    It '-Path (existing) clone & merge' {
+      $path = Join-Path $vcpkg_dir 'vcpkg'
+      { Update-Vcpkg -Path $vcpkg_dir -WhatIf *>$null } |
+        Should -not -Throw
+      (Update-Vcpkg -Path $vcpkg_dir -Quiet -WhatIf 1>$null) 3>&1 |
+        Should -Match 'Update-Repository: vcpkg not installed'
+      Test-Path (Join-Path $vcpkg_dir '*') | Should -Be $false
+      Test-Path -Path (Join-Path $PSScriptRoot 'vcpkg_source.hash') |
+        Should -Be $false
+    }
+    $vcpkg_dir = Join-Path (Join-Path 'TestDrive:\' 'vc 2') 'vcpkg'
+    It '-Path (non-existing) - creates directory' {
+      $path = Join-Path $vcpkg_dir 'vcpkg'
+      { Update-Vcpkg -Path $vcpkg_dir -Quiet -WhatIf *>$null } |
+        Should -not -Throw
+      (Update-Vcpkg -Path $vcpkg_dir -Quiet -WhatIf 1>$null) 3>&1 |
+        Should -Match 'Update-Repository: vcpkg not installed'
+      Test-Path (Join-Path $vcpkg_dir '*') | Should -Be $false
+      Test-Path -Path $vcpkg_dir -PathType Container | Should -Be $true
+    }
+    # clone / checkout
+    $vcpkg_dir = New-Item -Path 'TestDrive:\' -Name 'vc 3' -ItemType Directory
+    It '-FixedCommit: clone & checkout' {
+      $path = Join-Path $vcpkg_dir 'vcpkg'
+      { Update-Vcpkg -Path $vcpkg_dir `
+        -FixedCommit CF83E1357000000DF1542850D66D8007D620E405 -Quiet -WhatIf `
+        *>$null
+      } | Should -not -Throw
+      (Update-Vcpkg -Path $vcpkg_dir `
+        -FixedCommit CF83E1357000000DF1542850D66D8007D620E405 -Quiet -WhatIf `
+      1>$null) 3>&1 | should -Match 'Update-Repository: vcpkg not installed'
+      Test-Path (Join-Path $vcpkg_dir '*') | Should -Be $false
+    }
+  }
+  Context 'WhatIf & Latest; mock Location' {
+    Mock Assert-CI { return $false } -ModuleName Update-Vcpkg
+    Mock Select-VcpkgLocation { (Join-Path 'TestDrive:\' 'loc').ToString() } `
+      -ModuleName Update-Vcpkg
+    New-Item -Path 'TestDrive:\' -Name 'loc' -ItemType Directory
+
+    It 'no changes with -Latest -WhatIf' {
+      if (-not (Test-Command 'vcpkg version')) {
+        Set-ItResult -Skipped -Because 'requires installed vcpkg'
+      }
+      { Update-Vcpkg -Latest -Quiet -WhatIf 3>$null } | Should -not -Throw
+      Test-Path -Path (Join-Path $PSScriptRoot 'vcpkg_source.hash') |
+        Should -Be $false
+      Update-Vcpkg -Latest -Quiet -WhatIf 3>&1 |
+        Should -Match 'Update-Repository: vcpkg not installed'
+    }
+  }
+  Context 'WhatIf: build after retrieval from cache (mocked)' {
+    Mock Update-Repository { return $null } -ModuleName Update-Vcpkg
+    Mock Import-CachedVcpkg { return $true } -ModuleName Update-Vcpkg
+    Mock Test-IfReleaseWithIssues { return $true } -ModuleName Update-Vcpkg
+    $vcpkg_dir = New-Item -Path 'TestDrive:\' -Name 'vc 4' -ItemType Directory
+    # Mock vcpkg
+    ( 'param([String]$input)' +
+      'if ($input -eq "update") { Write-Output "No packages need updating."' +
+      '} elseif ($input -eq "upgrade") {' +
+      '  Write-Output "All installed packages are up-to-date"' +
+      '} else { Write-Output "..." }'
+    ) > (Join-Path $vcpkg_dir 'vcpkg.ps1')
+
+    It 'build after retrieval from cache (mocked)' {
+      { Update-Vcpkg -Path $vcpkg_dir -Quiet -WhatIf } | Should -not -Throw
+      Assert-MockCalled -CommandName Update-Repository `
+        -ModuleName update-Vcpkg -Times 1 -Exactly -Scope It
+      Assert-MockCalled -CommandName Import-CachedVcpkg `
+        -ModuleName update-Vcpkg -Times 1 -Exactly -Scope It
+      Assert-MockCalled -CommandName Test-IfReleaseWithIssues `
+        -ModuleName update-Vcpkg -Times 1 -Exactly -Scope It
+    }
+    Mock Test-IfReleaseWithIssues { return $false } -ModuleName Update-Vcpkg
+    It 'no build after retrieval from cache (mocked)' {
+      { Update-Vcpkg -Path $vcpkg_dir -Quiet -WhatIf } | Should -not -Throw
+      Assert-MockCalled -CommandName Update-Repository `
+        -ModuleName update-Vcpkg -Times 1 -Exactly -Scope It
+      Assert-MockCalled -CommandName Import-CachedVcpkg `
+        -ModuleName update-Vcpkg -Times 1 -Exactly -Scope It
+      Assert-MockCalled -CommandName Test-IfReleaseWithIssues `
+        -ModuleName update-Vcpkg -Times 1 -Exactly -Scope It
+    }
+  }
+
+  Context 'WhatIf: no cache needed' {
+    Mock Update-Repository { return $null } -ModuleName Update-Vcpkg
+    Mock Import-CachedVcpkg { return $true } -ModuleName Update-Vcpkg
+    Mock Test-IfReleaseWithIssues { return $false } -ModuleName Update-Vcpkg
+    Mock Assert-CI { return $true } -ModuleName Update-Vcpkg
+    Mock Test-Path { return $true } -ModuleName Update-Vcpkg
+    Mock Remove-Item { return $null } -ModuleName Update-Vcpkg
+#    Mock Remove-Item { return $null } -ModuleName Update-Vcpkg
+    $vcpkg_dir = New-Item -Path 'TestDrive:\' -Name 'vc 5' -ItemType Directory
+    # Mock vcpkg
+    ( 'param([String]$input)' +
+      'if ($input -eq "update") { Write-Output "No packages need updating."' +
+      '} elseif ($input -eq "upgrade") {' +
+      '  Write-Output "All installed packages are up-to-date"' +
+      '} else { Write-Output "..." }'
+    ) > (Join-Path $vcpkg_dir 'vcpkg.ps1')
+
+    It 'vcpkg is up-to-date' {
+      { Update-Vcpkg -Path $vcpkg_dir -Quiet -Verbose -WhatIf 4>$null } | Should -not -Throw
+      Assert-MockCalled -CommandName Update-Repository `
+        -ModuleName update-Vcpkg -Times 1 -Exactly -Scope It
+      Assert-MockCalled -CommandName Import-CachedVcpkg `
+        -ModuleName update-Vcpkg -Times 0 -Exactly -Scope It
+      Assert-MockCalled -CommandName Test-IfReleaseWithIssues `
+        -ModuleName update-Vcpkg -Times 1 -Exactly -Scope It
+      Assert-MockCalled -CommandName Remove-Item `
+        -ModuleName update-Vcpkg -Times 1 -Exactly -Scope It
+    }
+  }
+} # /Describe 'Update-Vcpkg'
+##====--------------------------------------------------------------------====##

--- a/C++/Update-Vcpkg.Tests.ps1
+++ b/C++/Update-Vcpkg.Tests.ps1
@@ -190,7 +190,7 @@ Describe 'Internal Test-ChangedVcpkgSource' {
           '2019.06.26-nohash' + '`n`nSee LICENSE.txt for license information."'
         ) > vcpkg.ps1
         New-Item .\toolsrc -ItemType Directory
-        'some text' > .\toolsrc\something.cpp 
+        'some text' > .\toolsrc\something.cpp
         git add *
         git commit -m 'initial' --quiet
         # no changes: do not create the .hash file.
@@ -228,7 +228,7 @@ Describe 'Internal Test-ChangedVcpkgSource' {
           '2019.06.26-nohash' + '`n`nSee LICENSE.txt for license information."'
         ) > vcpkg.ps1
         New-Item .\toolsrc -ItemType Directory
-        'some text' > .\toolsrc\something.cpp 
+        'some text' > .\toolsrc\something.cpp
         git add *
         git commit -m 'initial' --quiet
         # Verify operation.
@@ -304,7 +304,7 @@ Describe 'Internal Test-ChangedVcpkgSource' {
           '2019.06.26-nohash' + '`n`nSee LICENSE.txt for license information."'
         ) > vcpkg.ps1
         New-Item .\toolsrc -ItemType Directory
-        'some text' > .\toolsrc\something.cpp 
+        'some text' > .\toolsrc\something.cpp
         git add *
         git commit -m 'initial' --quiet
         It 'initial run - create vcpkg_source.hash' {

--- a/C++/Update-Vcpkg.psd1
+++ b/C++/Update-Vcpkg.psd1
@@ -1,6 +1,6 @@
 @{
 RootModule = 'Update-Vcpkg.psm1'
-ModuleVersion = '0.1'
+ModuleVersion = '0.1.1'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/C++/Update-Vcpkg.psd1
+++ b/C++/Update-Vcpkg.psd1
@@ -20,7 +20,7 @@ PowerShellVersion = '5.1'
 
 # Modules that must be imported into the global environment prior to importing this module
 RequiredModules = @(
-  @{ModuleName="${PSScriptRoot}\..\local\All.psd1"; ModuleVersion='0.3'},
+  @{ModuleName="${PSScriptRoot}\..\local\All.psd1"; ModuleVersion='0.4'},
   @{ModuleName="${PSScriptRoot}\..\General\Test-Command.psd1"; ModuleVersion='0.3'},
   @{ModuleName="${PSScriptRoot}\..\AppVeyor\Send-Message.psd1"; ModuleVersion='0.4'}
 )

--- a/C++/Update-Vcpkg.psd1
+++ b/C++/Update-Vcpkg.psd1
@@ -5,7 +5,7 @@ Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'
 # CompanyName = 'Unknown'
-Description = ''
+Description = 'Install the most recent release of vcpkg and update cached packages.'
 # GUID = 'd0a9150d-b6a4-4b17-a325-e3a24fed0aa9'
 # HelpInfoURI = ''
 

--- a/C++/Update-Vcpkg.psd1
+++ b/C++/Update-Vcpkg.psd1
@@ -1,13 +1,11 @@
 @{
-##====--------------------------------------------------------------------====##
-RootModule = ''
-ModuleVersion = '0.2'
+RootModule = 'Update-Vcpkg.psm1'
+ModuleVersion = '0.1'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'
 # CompanyName = 'Unknown'
-Description = 'Functionality specific to CI for C++ projects.'
-# ID used to uniquely identify this module
+Description = ''
 # GUID = 'd0a9150d-b6a4-4b17-a325-e3a24fed0aa9'
 # HelpInfoURI = ''
 
@@ -20,16 +18,18 @@ PowerShellVersion = '5.1'
 ##====--------------------------------------------------------------------====##
 # Import configuration
 
-NestedModules = @(
-  "${PSScriptRoot}\Install-Ninja.psd1",
-  "${PSScriptRoot}\Update-Vcpkg.psd1"
+# Modules that must be imported into the global environment prior to importing this module
+RequiredModules = @(
+  @{ModuleName="${PSScriptRoot}\..\local\All.psd1"; ModuleVersion='0.3'},
+  @{ModuleName="${PSScriptRoot}\..\General\Test-Command.psd1"; ModuleVersion='0.3'},
+  @{ModuleName="${PSScriptRoot}\..\AppVeyor\Send-Message.psd1"; ModuleVersion='0.4'}
 )
 
 ##====--------------------------------------------------------------------====##
 # Export configuration
 
 # Functions to export from this module
-FunctionsToExport = '*'
+FunctionsToExport = 'Update-Vcpkg'
 # Cmdlets to export from this module
 CmdletsToExport = ''
 # Variables to export from this module
@@ -38,9 +38,10 @@ VariablesToExport = ''
 AliasesToExport = ''
 
 ##====--------------------------------------------------------------------====##
-# List of all modules packaged with this module
-# ModuleList = @()
 # List of all files packaged with this module
-# FileList = @()
-
+FileList = @(
+  'Update-Vcpkg.psd1',
+  'Update-Vcpkg.psm1',
+  'Update-Vcpkg.Tests.ps1'
+)
 }

--- a/C++/Update-Vcpkg.psm1
+++ b/C++/Update-Vcpkg.psm1
@@ -274,7 +274,7 @@ function Export-CachedVcpkg {
   Process
   {
     if (Assert-CI) {
-      New-Item -Path $Destination -ItemType Directory -Force
+      New-Item -Path $Destination -ItemType Directory -Force 1>$null
       Resolve-Path -Path 'vcpkg*' |
         Select-String -Pattern '[\\\/]vcpkg(\.exe)?$' |
         ForEach-Object -Process {

--- a/C++/Update-Vcpkg.psm1
+++ b/C++/Update-Vcpkg.psm1
@@ -92,28 +92,10 @@ function Update-Vcpkg {
     # Default cache directory, for controlled cache application.
     $cache_dir = Join-Path (Join-Path (Join-Path $HOME 'Tools') 'cache') 'vcpkg'
 
-    # Temporary fix ----------------------------------------
-    if ($env:CI_WINDOWS -eq $null) {
-      Send-Message -Warning 'CI_WINDOWS and CI_LINUX not yet defined' -LogOnly
-      if ($PSVersionTable.PSVersion.Major -lt 6) {
-        if ((Get-WmiObject Win32_OperatingSystem).Caption -match 'Windows') {
-          $env:CI_WINDOWS = 'true'
-        }
-      } else {
-        if ((Get-CimInstance CIM_OperatingSystem).Caption -match 'Windows') {
-          $env:CI_WINDOWS = 'true'
-        }
-      }
+    if (Assert-Windows) {
+      $vcpkg = 'vcpkg.exe'
     } else {
-      Send-Message -Warning ('Remove unnecessary code from ' +
-        $MyInvocation.MyCommand) -LogOnly
-    }
-    # /Temporary fix ---------------------------------------
-
-    if ($env:CI_WINDOWS -eq 'true') {
-      $vcpkg = 'vcpkg.exe' # Windows
-    } else {
-      $vcpkg = 'vcpkg' # Linux
+      $vcpkg = 'vcpkg'
     }
 
     # Set installation location

--- a/C++/Update-Vcpkg.psm1
+++ b/C++/Update-Vcpkg.psm1
@@ -162,7 +162,7 @@ function Update-Vcpkg {
         (Test-Path (Join-Path $cache_dir $vcpkg) -PathType Leaf)
       ) {
         Write-Verbose 'Installed vcpkg is up-to-date.'
-        Remove-Item (Join-Path $cache_dir 'vcpkg')
+        Remove-Item (Join-Path $cache_dir $vcpkg)
       }
       # Build vcpkg
       if ($build) {

--- a/C++/Update-Vcpkg.psm1
+++ b/C++/Update-Vcpkg.psm1
@@ -164,9 +164,14 @@ function Update-Vcpkg {
         Add-EnvironmentPath -Path $Location
       }
     } finally {
-      if (Assert-CI -and -not (Test-Path $vcpkg -PathType Leaf) ) {
-        Write-Verbose 'Disabling cache update. Building vcpkg failed.'
-        $env:APPVEYOR_CACHE_SKIP_SAVE = 'true'
+      if ( (Assert-CI) -and -not (Test-Path $vcpkg -PathType Leaf) ) {
+        Send-Message -Warning 'Building vcpkg failed. Disabling cache update.' `
+          -Details (Join-Path $Location $vcpkg)
+        if ($PSCmdlet.ShouldProcess('APPVEYOR_CACHE_SKIP_SAVE',
+          'disable caching')
+        ) {
+          $env:APPVEYOR_CACHE_SKIP_SAVE = 'true'
+        }
       }
       Pop-Location
     }

--- a/C++/Update-Vcpkg.psm1
+++ b/C++/Update-Vcpkg.psm1
@@ -230,12 +230,13 @@ function Import-CachedVcpkg {
       return $true
     }
     # Add message log entry with instructions
-    ('Vcpkg has been rebuild, but their was no cache available.',"`n",
+    ('Vcpkg has been rebuild, but there was no cache available.',"`n",
     'Add the following to your AppVeyor configuration:',"`n`n",
     'cache:',"`n- '${Path}'`n`n",
     'Optionally, enable cacheing on failed builds to reduce build time ',
-    'for repeatedly failing jobs. Add in your AppVeyor configuration:',"`n`n",
-    'environment:', "`n",
+    'for repeatedly failing jobs.',"`n",
+    'Add in your AppVeyor configuration:',"`n`n",
+    'environment:',"`n",
     '  global:',"`n",
     '    APPVEYOR_SAVE_CACHE_ON_ERROR: true'
     ) -join '' |
@@ -411,7 +412,8 @@ function Test-ChangedVcpkgSource {
       'Add the following to your AppVeyor configuration:',"`n`n",
       'cache:',"`n- '${cache_txt}'`n`n",
       'Optionally, enable cacheing on failed builds to reduce build time ',
-      'for repeatedly failing jobs. Add in your AppVeyor configuration:',"`n`n",
+      'for repeatedly failing jobs.',"`n",
+      'Add in your AppVeyor configuration:',"`n`n",
       'environment:', "`n",
       '  global:',"`n",
       '    APPVEYOR_SAVE_CACHE_ON_ERROR: true'

--- a/C++/Update-Vcpkg.psm1
+++ b/C++/Update-Vcpkg.psm1
@@ -51,6 +51,8 @@ Set-StrictMode -Version Latest
 .EXAMPLE
   Update-Vcpkg -Path .\
 
+  Use a custom install directory for vcpkg, or point in to an installed version.
+  Can be used to create separate install directories, usable with CMake.
 .NOTES
   - `-Path <...> -WhatIf` always creates the target folder.
   - Caching on AppVeyor.

--- a/C++/Update-Vcpkg.psm1
+++ b/C++/Update-Vcpkg.psm1
@@ -1,0 +1,458 @@
+Set-StrictMode -Version Latest
+##====--------------------------------------------------------------------====##
+
+<#
+.SYNOPSIS
+  Updates the installed version of vcpkg and any installed packages.
+.DESCRIPTION
+  Single function installation/updating for vcpkg.
+.OUTPUTS
+  1. File: "vcpkg_source.hash" creation or modification in the same directory
+     as this script.
+  2. Instructions to the message API, on how to enable caching, when relevant.
+  3. AppVeyor: On failed build of vcpkg, cache saving is disabled with:
+     `$env:APPVEYOR_CACHE_SKIP_SAVE = 'true'`
+.EXAMPLE
+  Update-Vcpkg
+  -- Update vcpkg ...
+  -- Update vcpkg - git ...
+  -- Update vcpkg - git ... done
+  -- Update vcpkg - build ...
+  -- Update vcpkg - build ... done
+  INFO: vcpkg list
+  -- catch2:x64-windows        2.7.2-2          A modern, header-only test ...
+  -- gtest:x64-linux           2019-01-04-2     GoogleTest and GoogleMock ...
+  -- gtest:x64-windows         2019-01-04-2     GoogleTest and GoogleMock ...
+  -- ms-gsl:x64-linux          2019-04-19       Microsoft implementation of ...
+  -- ms-gsl:x64-windows        2019-04-19       Microsoft implementation of ...
+  INFO: vcpkg update
+  -- Using local portfile versions. To update the local portfiles, use `git pull
+  -- No packages need updating.
+  -- Update vcpkg ... done 
+
+  Default operation. Use the latest versions of all packages and rebuild the
+  vcpkg tools only on version number changes.
+.EXAMPLE
+  Update-Vcpkg -Quiet
+
+  Suppress informational output.
+.EXAMPLE
+  Update-Vcpkg -FixedCommit f700dee8eb4677d89d3919519613dee5e22c766e
+
+  Use to keep a fixed dependencies state. Requires the full commit hash from the
+  vcpkg repository.
+.EXAMPLE
+  Update-Vcpkg -Latest
+
+  Rebuild the vcpkg tool if any change has been made in the "toolsrc" directory.
+  This has been recommended by the developers and can prevent issues when a
+  braking change is introduced in the tool without a version number update.
+  But, this can also result in frequent rebuilds when vcpkg is in development.
+.EXAMPLE
+  Update-Vcpkg -Path .\
+
+.NOTES
+  - `-Path <...> -WhatIf` always creates the target folder.
+  - Caching on AppVeyor.
+    Prevent unnecessary rebuilds of vcpkg by adding $HOME/Tools/cache.
+    For ports that need to be build add the "C:\Tools\vcpkg\installed" folder.
+#>
+function Update-Vcpkg {
+  [CmdletBinding(SupportsShouldProcess,ConfirmImpact='Medium')]
+#  [OutputType([System.Management.Automation.PathInfo])]
+  param(
+    # Rebuild vcpkg on each vcpkg tool source change.
+    [Switch]$Latest,
+    [ValidatePattern('[0-9a-fA-F]{40}')] # full SHA1 hash
+    [ValidateNotNullOrEmpty()]
+    [Alias('Commit')]
+    # Git commit hash to checkout to use a specific state of the vcpkg library.
+    [String]$FixedCommit,
+    [ValidateScript({
+      (Test-Path "$_" -IsValid) -and
+        (New-Item -Path "$_" -ItemType Directory -Force |
+          Test-Path -PathType Container
+        )
+    })]
+    [ValidateNotNullOrEmpty()]
+    # Custom directory to find or install vcpkg.
+    [String]$Path,
+    [Alias('q')]
+    # Reduce console output.
+    [Switch]$Quiet
+  )
+  Begin
+  {
+    Get-CommonFlagsCaller $PSCmdlet $ExecutionContext.SessionState
+
+    if (-not $Quiet) { Write-Host "-- Update vcpkg ..." }
+
+    # Default cache directory, for controlled cache application.
+    $cache_dir = Join-Path (Join-Path (Join-Path $HOME 'Tools') 'cache') 'vcpkg'
+
+    # Set installation location
+    if ($Path) {
+      $Location = $Path
+    } else {
+      $Location = Select-VcpkgLocation
+    }
+  }
+  Process
+  {
+    try {
+      Push-Location $Location
+
+      # Git operations
+      if (-not $Quiet) { Write-Host "-- Update vcpkg - git ..." }
+      Update-Repository -Commit:$FixedCommit
+      if (-not $Quiet) { Write-Host "-- Update vcpkg - git ... done" }
+
+      # Determine if (re)building is necessary
+      $build = $false
+      if ($Latest) {
+        $null = Import-CachedVcpkg
+        if (Test-ChangedVcpkgSource) {
+          $build = $true
+        }
+      } elseif (-not (Test-Path 'vcpkg' -PathType Leaf) -or # no vcpkg installed
+        (Test-Command './vcpkg update' `
+          -match 'different source is available for vcpkg') -or
+        (Test-IfReleaseWithIssues)
+      ) {
+        if (Import-CachedVcpkg) {
+          $build = ( (Test-Command './vcpkg update' `
+            -match 'different source is available for vcpkg') -or
+            (Test-IfReleaseWithIssues)
+          )
+        } else { $build = $true }
+      } elseif ( (Assert-CI) -and
+        (Test-Path (Join-Path $cache_dir 'vcpkg') -PathType Leaf)
+      ) {
+        Write-Verbose 'Installed vcpkg is up-to-date.'
+        Remove-Item (Join-Path $cache_dir 'vcpkg')
+      }
+      # Build vcpkg
+      if ($build) {
+        if (-not $Quiet) { Write-Host "-- Update vcpkg - build ..." }
+        if ($PSCmdlet.ShouldProcess('vcpkg', 'bootstrap')) {
+          ./bootstrap-vcpkg.bat 1>$null
+          Export-CachedVcpkg
+        }
+        if (-not $Quiet) { Write-Host "-- Update vcpkg - build ... done" }
+      }
+      # Integrate install
+      if ($PSCmdlet.ShouldProcess('vcpkg', 'integrate install')) {
+        ./vcpkg integrate install 1>$null
+      }
+      # Add to PATH
+      if (-not (Test-Command 'vcpkg version') ) {
+        Add-EnvironmentPath -Path $Location
+      }
+    } finally {
+      if (Assert-CI -and -not (Test-Path 'vcpkg' -PathType Leaf) ) {
+        Write-Verbose 'Disabling cache update. Building vcpkg failed.'
+        $env:APPVEYOR_CACHE_SKIP_SAVE = 'true'
+      }
+      Pop-Location
+    }
+  }
+  End
+  {
+    if (-not (Test-Command 'vcpkg version') ) {
+      if (-not $Quiet) { Write-Host "-- Update vcpkg ... failed" }
+      Send-Message -Error 'vcpkg install failed' `
+        -ContinueOnError:$WhatIfPreference
+      return $null
+    }
+    # Update packages
+    vcpkg list   | Send-Message 'vcpkg list' -LogOnly:$Quiet
+    vcpkg update | Send-Message 'vcpkg update' -LogOnly:$Quiet
+    if (!($(vcpkg upgrade) -match "^All installed packages are up-to-date")) {
+      if ($PSCmdlet.ShouldProcess('upgrade installed packages')) {
+        vcpkg upgrade --no-dry-run
+      }
+    }
+    if (-not $Quiet) { Write-Host "-- Update vcpkg ... done" }
+  }
+} #/ function Update-Vcpkg
+##====--------------------------------------------------------------------====##
+
+<#
+.SYNOPSIS
+  When available, copies the vcpkg executable from the cache.
+.DESCRIPTION
+  Only operational on AppVeyor, no effect on other systems.
+  Copies vcpkg or vcpkg.exe from the cache directory to the current directory.
+
+  Preconditions:
+  - Requires `$cache_dir` to be defined in the calling scope.
+    This is only available within the module defining this function.
+.OUTPUTS
+  Returns a boolean representing the existence of the cached file.
+.EXAMPLE
+  Import-CachedVcpkg
+#>
+function Import-CachedVcpkg {
+  [CmdletBinding(SupportsShouldProcess,ConfirmImpact='Low')]
+  [OutputType([Bool])]
+  param()
+  Begin
+  {
+    Get-CommonFlagsCaller $PSCmdlet $ExecutionContext.SessionState
+
+    $Path = Get-Variable -Scope 1 -Name 'cache_dir' -ValueOnly
+  }
+  Process
+  {
+    if ( (Assert-CI) -and
+      (Test-Path (Join-Path $Path 'vcpkg*') -PathType Leaf)
+    ) {
+      Resolve-Path -Path (Join-Path $Path 'vcpkg*') |
+        Select-String -Pattern '[\\\/]vcpkg(\.exe)?$' |
+        ForEach-Object -Process { Copy-Item "$_" -Force }
+      return $true
+    }
+    return $false
+  }
+  End {}
+}
+##====--------------------------------------------------------------------====##
+
+<#
+.SYNOPSIS
+  Copies the vcpkg(.exe) to the cache directory.
+.DESCRIPTION
+  Only operational on AppVeyor, no effect on other systems.
+  Creates the cache folder when not present.
+
+  Preconditions:
+  - vcpkg(.exe) present in current directory.
+  - Requires `$cache_dir` to be defined in the calling scope.
+    This is only available within the module defining this function.
+.EXAMPLE
+  Export-CachedVcpkg
+#>
+function Export-CachedVcpkg {
+  [CmdletBinding(SupportsShouldProcess,ConfirmImpact='Medium')]
+  param()
+  Begin
+  {
+    Get-CommonFlagsCaller $PSCmdlet $ExecutionContext.SessionState
+
+    $Destination = Get-Variable -Scope 1 -Name 'cache_dir' -ValueOnly
+  }
+  Process
+  {
+    if (Assert-CI) {
+      New-Item -Path $Destination -ItemType Directory -Force
+      Resolve-Path -Path 'vcpkg*' |
+        Select-String -Pattern '[\\\/]vcpkg(\.exe)?$' |
+        ForEach-Object -Process {
+          Copy-Item "$_" -Destination $Destination -Force
+        }
+    }
+  }
+  End {}
+}
+##====--------------------------------------------------------------------====##
+
+<#
+.SYNOPSIS
+  Returns the install location of vcpkg or fallback to a default location.
+.DESCRIPTION
+  Tries to find an existing vcpkg installation:
+  1. in the standard location used on AppVeyor.
+  2. if vcpkg is callable, get the install location.
+  3. fallback to using the current user's home directory. Creating
+     "$HOME/Tools/vcpkg"
+#>
+function Select-VcpkgLocation {
+  [CmdletBinding(SupportsShouldProcess,ConfirmImpact='Medium')]
+  [OutputType([String])]
+  param()
+  Begin
+  {
+    Get-CommonFlagsCaller $PSCmdlet $ExecutionContext.SessionState
+  }
+  Process
+  {
+    # Find installation location
+    if ( (Assert-CI) -and ($env:CI_WINDOWS -eq 'true') -and
+      (Test-Path 'C:\Tools\vcpkg\vcpkg.exe' -PathType Leaf)
+    ) {
+      return 'C:\Tools\vcpkg' # default location on AppVeyor (Windows)
+    } elseif (Test-Command 'vcpkg version') {
+      return (
+        Get-Command vcpkg | Select-Object -ExpandProperty Definition
+      ) -replace '[\\\/]vcpkg(.exe)?$',''
+    } else {
+      $Location = Join-Path (Join-Path $HOME 'Tools') 'vcpkg'
+      if ($PSCmdlet.ShouldProcess($Location, 'Create Directory')) {
+        return (New-Item $Location -ItemType Directory -Force)
+      } else {
+        return $Location
+      }
+    }
+  }
+  End {}
+}
+##====--------------------------------------------------------------------====##
+
+<#
+.SYNOPSIS
+  Checks to determine if a rebuild of vcpkg is required.
+#>
+function Test-IfReleaseWithIssues {
+  [OutputType([Bool])]
+  param()
+
+  $match = 'version (0\.0\.113|2018\.11\.23)'
+  if ($(./vcpkg version) -match $match) {
+    Send-Message -Warning 'This vcpkg release has known issues. Rebuilding ...'
+    return $true
+  } else { return $false }
+}
+##====--------------------------------------------------------------------====##
+
+<#
+.SYNOPSIS
+  Determine if the vcpkg tool source has been updated since the last build.
+.OUTPUTS
+  1. Boolean: True | False
+     True: on first use or without caching.
+     False: when matching hash.
+  2. File: "vcpkg_source.hash" creation or modification in the same directory
+     as this script.
+  3. Instructions to the message API, on how to enable caching, when relevant.
+.NOTES
+  Requires the current working directory to be the root vcpkg directory and a
+  git working directory.
+#>
+function Test-ChangedVcpkgSource {
+  [CmdletBinding(SupportsShouldProcess,ConfirmImpact='Medium')]
+  [OutputType([Bool])]
+  param()
+  Begin 
+  {
+    Get-CommonFlagsCaller $PSCmdlet $ExecutionContext.SessionState
+
+    $executable = 'vcpkg.exe'
+    if (-not (Test-Path $executable -PathType Leaf) ) { $executable = 'vcpkg' }
+
+    $loc_1 = Get-Variable -Scope 1 -Name 'cache_dir' -ValueOnly `
+      -ErrorAction SilentlyContinue
+    $loc_2 = Join-Path $PSScriptRoot 'vcpkg_source.hash'
+    if ($loc_1 -and (Test-Path $loc_1 -PathType Container) ) {
+      $hash_file = Join-Path $loc_1 'vcpkg_source.hash'
+      if (Test-Path $loc_2 -PathType Leaf) {
+        Move-Item -Path $loc_2 -Destination $loc_1
+      }
+    } else {
+      $hash_file = $loc_2
+    }
+  }
+  Process
+  {
+    if (-not (Test-Command 'git status')) {
+      if ($WhatIfPreference) { $vcpkg_src_hash = ''; return $true }
+      else { throw 'not a git working directory' }
+    }
+
+    # Get hash from git
+    $vcpkg_src_hash = git log --format=format:"%H" --max-count=1 -- toolsrc
+
+    if (Test-Path -LiteralPath $hash_file -PathType Leaf) {
+      if ( (Get-Content -LiteralPath $hash_file) -eq $vcpkg_src_hash ) {
+        return $false # no change
+      } else {
+        return $true  # confirmed change
+      }
+    }
+
+    # Add message log entry with instructions
+    ('The use of `Update-Vcpkg -Latest` without caching, results in a full ',
+    'rebuild of vcpkg for each build job.', "`n",
+    'Add the following to your AppVeyor configuration:',"`n`n",
+    'cache:',"`n",
+    "- '$(Join-Path $PWD.ProviderPath $executable)'`n",
+    "- '${hash_file}'`n`n",
+    'Optionally, enable cache updating on failed builds to reduce build time ',
+    'for repeatedly failing jobs. Add in your AppVeyor configuration:',"`n`n",
+    'environment:', "`n",
+    '  global:',"`n",
+    '    APPVEYOR_SAVE_CACHE_ON_ERROR: true'
+    ) -join '' |
+    Send-Message -Warning 'No Cache Found (Update-Vcpkg -Latest)' `
+      -NoNewLine -HideDetails
+
+    return $true # unknown assume change
+  }
+  End
+  {
+    # Update/ create file, to be cached
+    if ($vcpkg_src_hash) {
+      $vcpkg_src_hash > $hash_file
+    }
+  }
+}
+##====--------------------------------------------------------------------====##
+
+<#
+.SYNOPSIS
+  Initialize or update the git repository.
+.NOTES
+  Operates only on the current directory.
+#>
+function Update-Repository {
+  [CmdletBinding(SupportsShouldProcess,ConfirmImpact='Medium')]
+  param(
+    # Git commit hash to checkout.
+    [String]$Commit
+  )
+  Begin
+  {
+    Get-CommonFlagsCaller $PSCmdlet $ExecutionContext.SessionState
+
+    if ($VerbosePreference -eq 'SilentlyContinue') { $git_quiet = '--quiet' }
+    else { $git_quiet = '' }
+  }
+  Process
+  {
+    if (Test-Path '*' -PathType Leaf) {
+      if (Test-Command 'git status') {
+        if (Test-Command 'git remote' -Match '.+') {
+          if ($PSCmdlet.ShouldProcess($PWD.ProviderPath, 'git fetch')) {
+            git fetch $git_quiet
+          }
+        } else {
+          Send-Message -Error ( ($MyInvocation.MyCommand).ToString() +
+          ': no remote repositories defined') -Details $PWD.ProviderPath
+        }
+      } else {
+        Send-Message -Error ( ($MyInvocation.MyCommand).ToString() +
+          ': Not empty and not a git working directory'
+        ) -Details $PWD.ProviderPath
+      }
+    } else { # empty folder
+      Send-Message -Warning ( ($MyInvocation.MyCommand).ToString() +
+        ': vcpkg not installed in the expected location.'
+      ) -Details $PWD.ProviderPath
+      if ($PSCmdlet.ShouldProcess($PWD.ProviderPath, 'git clone')) {
+        git clone https://github.com/Microsoft/vcpkg $git_quiet .\
+      }
+    }
+    if ($Commit) {
+      if ($PSCmdlet.ShouldProcess($PWD.ProviderPath, 'git checkout')) {
+        git checkout $git_quiet $Commit
+      }
+    } else {
+      if ($PSCmdlet.ShouldProcess($PWD.ProviderPath, 'git merge')) {
+        git merge $git_quiet
+      }
+    }
+  }
+  End {}
+}
+
+##====--------------------------------------------------------------------====##
+Export-ModuleMember -Function Update-Vcpkg

--- a/C++/Update-Vcpkg.psm1
+++ b/C++/Update-Vcpkg.psm1
@@ -125,6 +125,13 @@ function Update-Vcpkg {
   }
   Process
   {
+    if ( (Assert-CI) -and
+      ($env:APPVEYOR_BUILD_WORKER_IMAGE -match 'Visual Studio 2013')
+    ) {
+      Send-Message -Error 'Vcpkg requires minimally Visual Studio 2015.' `
+        -ContinueOnError
+      return $null
+    }
     try {
       Push-Location $Location
 
@@ -187,7 +194,9 @@ function Update-Vcpkg {
     if (-not (Test-Command 'vcpkg version') ) {
       if (-not $Quiet) { Write-Host "-- Update vcpkg ... failed" }
       Send-Message -Error 'vcpkg install failed' `
-        -ContinueOnError:$WhatIfPreference
+        -ContinueOnError:$($WhatIfPreference -or
+          ($env:APPVEYOR_BUILD_WORKER_IMAGE -match 'Visual Studio 2013')
+        )
       return $null
     }
     # Update packages

--- a/C++/Update-Vcpkg.psm1
+++ b/C++/Update-Vcpkg.psm1
@@ -28,7 +28,7 @@ Set-StrictMode -Version Latest
   INFO: vcpkg update
   -- Using local portfile versions. To update the local portfiles, use `git pull
   -- No packages need updating.
-  -- Update vcpkg ... done 
+  -- Update vcpkg ... done
 
   Default operation. Use the latest versions of all packages and rebuild the
   vcpkg tools only on version number changes.
@@ -370,7 +370,7 @@ function Test-ChangedVcpkgSource {
   [CmdletBinding(SupportsShouldProcess,ConfirmImpact='Medium')]
   [OutputType([Bool])]
   param()
-  Begin 
+  Begin
   {
     Get-CommonFlagsCaller $PSCmdlet $ExecutionContext.SessionState
 

--- a/C++/Update-Vcpkg.psm1
+++ b/C++/Update-Vcpkg.psm1
@@ -240,6 +240,8 @@ function Import-CachedVcpkg {
     Get-CommonFlagsCaller $PSCmdlet $ExecutionContext.SessionState
 
     $Path = Get-Variable -Scope 1 -Name 'cache_dir' -ValueOnly
+    $install_dir = Join-Path (
+      Get-Variable -Scope 1 -Name 'Location' -ValueOnly) 'installed'
   }
   Process
   {
@@ -255,6 +257,8 @@ function Import-CachedVcpkg {
     ('Vcpkg has been rebuild, but there was no cache available.',"`n",
     'Add the following to your AppVeyor configuration:',"`n`n",
     'cache:',"`n- '${Path}'`n`n",
+    'To cache packages that take a significant time to build, add:',"`n",
+    "- '${install_dir}'`n`n",
     'Optionally, enable cacheing on failed builds to reduce build time ',
     'for repeatedly failing jobs.',"`n",
     'Add in your AppVeyor configuration:',"`n`n",

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Install libraries:
 These modules can create persistent files in the file-system.
 These are primarily the `Install-*` functions.
 With the exception of installers that install software in their default location
-or update software present on the system (notably 
+or update software present on the system (notably
 `Update-Vcpkg`) these files are all located in `~/Tools`.
 
 <!-------------------------------------------------------------><a id="dev"></a>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-------------------------------------------------------------><a id="top"></a>
-# AppVeyorHelpers
+# 🔧 AppVeyorHelpers
 <!----------------------------------------------------------------------------->
 <!-- Badges -->
 [![Build status][AppVeyor-badge]][AppVeyor-link]
@@ -20,7 +20,7 @@ Windows.
 - [License](#license)
 
 <!--------------------------------------------------------><a id="features"></a>
-## Features
+## 🏱 Features
 <!----------------------------------------------------------------------------->
 - Keep the build-log clean and informative.
   - Send notifications and detailed reports to the AppVeyor message API.
@@ -28,7 +28,7 @@ Windows.
   - Encapsulate common complex commands in function calls.
 
 <!-----------------------------------------------------------><a id="usage"></a>
-## Usage
+## 💻 Usage
 <!----------------------------------------------------------------------------->
 Usage on AppVeyor.<br />
 `appveyor.yml`:
@@ -42,7 +42,7 @@ init:
 ````
 
 <!-------------------------------------------------------------><a id="dev"></a>
-## Development
+## 🏗 Development
 <!----------------------------------------------------------------------------->
 Unit tests are implemented with [Pester][Pester-link].
 To run all unit-tests (and code coverage) for this module call:
@@ -55,7 +55,7 @@ Invoke-Pester -Script .\<script>.Tests.ps1 -CodeCoverage .\<script>.psm1
 ```
 
 <!---------------------------------------------------------><a id="license"></a>
-## License
+## ⚖ License
 <!----------------------------------------------------------------------------->
 Code licensed under the [MIT License](./LICENSE).
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Windows.
 <!-- TOC -->
 - [Features](#features)
 - [Usage](#usage)
+- [Notes](#notes)
 - [Development](#dev)
 - [License](#license)
 
@@ -26,33 +27,66 @@ Windows.
   - Send notifications and detailed reports to the AppVeyor message API.
   - Upload test results to the AppVeyor Test API.
   - Encapsulate common complex commands in function calls.
+- For use on [AppVeyor][AppVeyor-link] and local systems.  
+  __Minimum required: PowerShell v5.1, tested on AppVeyor Windows images.__
+- Support more build configurations.
+  - Use Ninja for faster builds (with CMake projects).
+- *\[C++\]* Improved vcpkg usage.
 
 <!-----------------------------------------------------------><a id="usage"></a>
 ## 💻 Usage
 <!----------------------------------------------------------------------------->
-Usage on AppVeyor.<br />
-`appveyor.yml`:
-````
+Usage on AppVeyor. (appveyor.yml)
+
+Import the PowerShell module at the start of the build session:
+````YAML
 init:
 - ps: |
-    New-Item -ItemType Directory -Force ~\tools | pushd
+    New-Item -ItemType Directory -Force ~/Tools | pushd
     git clone https://github.com/Farwaykorse/AppVeyorHelpers.git --quiet
     Import-Module -Name .\AppVeyorHelpers
     popd
 ````
+
+__A few usage examples:__  
+Display the build configuration and the installed CMake version:
+```YAML
+- ps: Show-SystemInfo -CMake
+```
+
+Install tools:
+`````YAML
+install:
+- ps: Install-Ninja -Tag v1.9.0 -AddToPath
+`````
+
+Install libraries:
+````YAML
+- ps: Update-Vcpkg
+- ps: vcpkg install ms-gsl:x64-Windows
+````
+
+<!-----------------------------------------------------------><a id="notes"></a>
+## 📝 Notes
+<!----------------------------------------------------------------------------->
+These modules can create persistent files in the file-system.
+These are primarily the `Install-*` functions.
+With the exception of installers that install software in their default location
+or update software present on the system (notably 
+`Update-Vcpkg`) these files are all located in `~/Tools`.
 
 <!-------------------------------------------------------------><a id="dev"></a>
 ## 🏗 Development
 <!----------------------------------------------------------------------------->
 Unit tests are implemented with [Pester][Pester-link].
 To run all unit-tests (and code coverage) for this module call:
-```
+```PowerShell
 .\RunTests.ps1 -Coverage
 ```
 or [run Invoke-Pester][Invoke-Pester-link] for an individual sub-module:
-```
+`````PowerShell
 Invoke-Pester -Script .\<script>.Tests.ps1 -CodeCoverage .\<script>.psm1
-```
+`````
 
 <!---------------------------------------------------------><a id="license"></a>
 ## ⚖ License

--- a/local/All.psd1
+++ b/local/All.psd1
@@ -1,7 +1,7 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = ''
-ModuleVersion = '0.3'
+ModuleVersion = '0.4'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'
@@ -32,6 +32,7 @@ NestedModules = @(
 FunctionsToExport = @(
   'Add-EnvironmentPath',
   'Assert-CI',
+  'Assert-Windows',
   'Get-CommonFlagsCaller'
 )
 # Cmdlets to export from this module

--- a/local/All.psd1
+++ b/local/All.psd1
@@ -1,7 +1,7 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = ''
-ModuleVersion = '0.2'
+ModuleVersion = '0.3'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'
@@ -21,7 +21,8 @@ PowerShellVersion = '5.1'
 
 NestedModules = @(
   "${PSScriptRoot}\CI.psd1",
-  "${PSScriptRoot}\Get-CommonFlagsCaller.psm1"
+  "${PSScriptRoot}\Get-CommonFlagsCaller.psm1",
+  "${PSScriptRoot}\EnvironmentPath.psd1"
 )
 
 ##====--------------------------------------------------------------------====##
@@ -29,6 +30,7 @@ NestedModules = @(
 
 # Functions to export from this module
 FunctionsToExport = @(
+  'Add-EnvironmentPath',
   'Assert-CI',
   'Get-CommonFlagsCaller'
 )

--- a/local/CI.Tests.ps1
+++ b/local/CI.Tests.ps1
@@ -12,10 +12,79 @@ Describe 'Assert-CI' {
       -Because $msg_documentation
   }
   It 'checks if on a CI platform' {
+    { Assert-CI } | Should -not -Throw
+    (Assert-CI).GetType().Name | Should -Be 'Boolean'
     if ($env:APPVEYOR -or $env:CI) {
       Assert-CI | Should -Be $true
     } else {
       Assert-CI | Should -Be $false
     }
   }
+}
+
+##====--------------------------------------------------------------------====##
+Describe 'Assert-Windows' {
+  It 'has documentation' {
+    Get-Help Assert-Windows | Out-String | Should -MatchExactly 'SYNOPSIS' `
+      -Because $msg_documentation
+  }
+  It 'checks if on Microsoft Windows' {
+    { Assert-Windows } | Should -not -Throw
+    (Assert-Windows).GetType().Name | Should -Be 'Boolean'
+  }
+  It 'expected environment' {
+    if (Assert-CI) {
+      $env:CI_WINDOWS | Should -not -Be $null
+      $env:CI_LINUX | Should -not -Be $null
+      $env:CI_WINDOWS | Should -BeIn @('True', 'False')
+      $env:CI_LINUX | Should -BeIn @('True', 'False')
+      if ($env:CI_WINDOWS -ceq 'True') {
+        $env:CI_LINUX | Should -BeExactly 'False'
+      } else {
+        $env:CI_WINDOWS | Should -BeExactly 'False'
+        $env:CI_LINUX | Should -BeExactly 'True'
+      }
+    } else {
+      $env:CI_WINDOWS | Should -Be $null
+      $env:CI_LINUX | Should -Be $null
+    }
+  }
+  It 'expected output' {
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+      Assert-Windows | Should -Be $true
+      (Get-WmiObject Win32_OperatingSystem).Caption | Should -Match 'Windows'
+    } else {
+      if ((Get-CimInstance CIM_OperatingSystem).Caption -Match 'Windows') {
+        Assert-Windows | Should -Be $true
+        (Get-CimInstance CIM_OperatingSystem).Caption |
+          Should -Match 'Microsoft Windows'
+      } else {
+        Assert-Windows | Should -Be $false
+      }
+    }
+  }
+  $original_CI_WINDOWS = $env:CI_WINDOWS
+  It 'use environment variable CI_WINDOWS' {
+    $env:CI_WINDOWS = 'True'
+    Assert-Windows | Should -Be $true
+    $env:CI_WINDOWS = 'False'
+    Assert-Windows | Should -Be $false
+    $env:CI_WINDOWS = $true
+    Assert-Windows | Should -Be $true
+    $env:CI_WINDOWS = $false
+    Assert-Windows | Should -Be $false
+    $env:CI_WINDOWS = 1
+    Assert-Windows | Should -Be $false
+    $env:CI_WINDOWS = 'someText'
+    Assert-Windows | Should -Be $false
+  }
+  $env:CI_WINDOWS = $null
+  It 'PowerShell 5: only on Windows' {
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+      Assert-Windows | Should -Be $true
+    } else {
+      Set-ItResult -Inconclusive -Because 'ran in pwsh'
+    }
+  }
+  $env:CI_WINDOWS = $original_CI_WINDOWS
 }

--- a/local/CI.psd1
+++ b/local/CI.psd1
@@ -6,7 +6,7 @@
 #>
 @{
 RootModule = 'CI.psm1'
-ModuleVersion = '0.2'
+ModuleVersion = '0.3'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'
@@ -51,7 +51,7 @@ PowerShellVersion = '5.1'
 # Export configuration
 
 # Functions to export from this module
-FunctionsToExport = 'Assert-CI'
+FunctionsToExport = @('Assert-CI', 'Assert-Windows')
 # Cmdlets to export from this module
 CmdletsToExport = ''
 # Variables to export from this module

--- a/local/CI.psm1
+++ b/local/CI.psm1
@@ -13,4 +13,19 @@ function Assert-CI {
 }
 ##====--------------------------------------------------------------------====##
 
-Export-ModuleMember -Function Assert-CI
+<#
+.SYNOPSIS
+  Checks if executed on the Microsoft Windows Platform.
+#>
+function Assert-Windows {
+  if ($env:CI_WINDOWS -ne $null) {
+    return ($env:CI_WINDOWS -ceq 'True')
+  }
+  return (
+    ($PSVersionTable.PSVersion.Major -lt 6) -or
+    ((Get-CimInstance CIM_OperatingSystem).Caption -match 'Windows')
+  )
+}
+##====--------------------------------------------------------------------====##
+
+Export-ModuleMember -Function Assert-CI, Assert-Windows

--- a/local/EnvironmentPath.Tests.ps1
+++ b/local/EnvironmentPath.Tests.ps1
@@ -1,0 +1,65 @@
+Import-Module -Name "${PSScriptRoot}\EnvironmentPath.psd1" -Force
+
+Set-StrictMode -Version Latest
+
+##====--------------------------------------------------------------------====##
+$global:msg_documentation = 'at least 1 empty line above documentation'
+
+##====--------------------------------------------------------------------====##
+Describe 'Add-EnvironmentPath' {
+  It 'has documentation' {
+    Get-Help Add-EnvironmentPath | Out-String |
+      Should -MatchExactly 'SYNOPSIS' -Because $msg_documentation
+  }
+  It 'supports -WhatIf and -Confirm' {
+    Get-Command -Name Add-EnvironmentPath -Syntax |
+      Should -Match '-Whatif.*-Confirm'
+  }
+  Context 'Input Validation' {
+    It 'throws on missing -Pat' {
+      { Add-EnvironmentPath } | Should -Throw 'Path is a required parameter'
+    }
+    It 'throws on empty -Path' {
+      { Add-EnvironmentPath -Path } | Should -Throw 'missing an argument'
+    }
+    It 'throws on empty string -Path' {
+      { Add-EnvironmentPath -Path '' } |
+        Should -Throw 'argument is null or empty'
+    }
+    It 'throws on $null -Path' {
+      { Add-EnvironmentPath -Path $null } |
+        Should -Throw 'argument is null or empty'
+    }
+    It 'throws on invalid -Path' {
+      { Add-EnvironmentPath -Path 'TestDrive:\non-existing' } |
+        Should -Throw 'validation script'
+      New-Item -Path 'TestDrive:\' -Name 'file' -ItemType File
+      { Add-EnvironmentPath -Path 'TestDrive:\file' } |
+        Should -Throw 'validation script'
+      New-Item -Path 'TestDrive:\' -Name 'folder' -ItemType Directory
+      { Add-EnvironmentPath -Path 'TestDrive:\fold*' } |
+        Should -Throw 'validation script' -Because 'no wildcards accepted'
+    }
+  }
+  Context 'WhatIf' {
+    $backup = $env:PATH
+    It 'no throw operation' {
+      { Add-EnvironmentPath -Path $HOME -WhatIf } | Should -not -Throw
+      $env:PATH | Should -not -Match ('^' + ($HOME -replace '\\','\\') + ';.*')
+    }
+    It 'no change' {
+      $env:PATH | Should -Be $backup
+    }
+    $env:PATH = $backup
+  }
+  Context 'normal' {
+    $backup = $env:PATH
+    It 'no throw operation' {
+      { Add-EnvironmentPath -Path $HOME } | Should -not -Throw
+      $env:PATH | Should -Match ('^' + ($HOME -replace '\\','\\') + ';.+')
+    }
+    $env:PATH = $backup
+  }
+}
+
+##====--------------------------------------------------------------------====##

--- a/local/EnvironmentPath.psd1
+++ b/local/EnvironmentPath.psd1
@@ -1,0 +1,62 @@
+@{
+RootModule = 'EnvironmentPath.psm1'
+ModuleVersion = '0.1'
+Author = 'Roelf-Jilling Wolthuis'
+Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
+Code released under the MIT license.'
+# CompanyName = 'Unknown'
+Description = '$env:PATH modification.'
+# GUID = 'd0a9150d-b6a4-4b17-a325-e3a24fed0aa9'
+# HelpInfoURI = ''
+
+##====--------------------------------------------------------------------====##
+# Requirements
+
+# Minimum version of the Windows PowerShell engine required by this module
+PowerShellVersion = '5.1'
+
+##====--------------------------------------------------------------------====##
+# Import configuration
+
+# Script files (.ps1) that are run in the caller's environment prior to importing this module
+# ScriptsToProcess = @()
+# Type files (.ps1xml) to be loaded when importing this module
+# TypesToProcess = @()
+# Format files (.ps1xml) to be loaded when importing this module
+# FormatsToProcess = @()
+# Assemblies that must be loaded prior to importing this module
+# RequiredAssemblies = @()
+# Modules that must be imported into the global environment prior to importing this module
+# RequiredModules = @()
+# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+# NestedModules = @()
+
+##====--------------------------------------------------------------------====##
+# Export configuration
+
+# Functions to export from this module
+FunctionsToExport = 'Add-EnvironmentPath'
+# Cmdlets to export from this module
+CmdletsToExport = ''
+# Variables to export from this module
+VariablesToExport = ''
+# Aliases to export from this module
+AliasesToExport = ''
+
+# Private data to pass to the module specified in RootModule/ModuleToProcess
+# PrivateData = ''
+
+# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+# DefaultCommandPrefix = ''
+
+##====--------------------------------------------------------------------====##
+# List of all modules packaged with this module
+# ModuleList = @()
+
+# List of all files packaged with this module
+FileList = @(
+  'EnvironmentPath.psd1',
+  'EnvironmentPath.psm1',
+  'EnvironmentPath.Tests.ps1'
+)
+}

--- a/local/EnvironmentPath.psm1
+++ b/local/EnvironmentPath.psm1
@@ -11,7 +11,7 @@ function Add-EnvironmentPath {
     [ValidateScript({ Test-Path -LiteralPath "$_" -PathType 'Container' })]
     [ValidateNotNullOrEmpty()]
     [String]$Path = $(throw 'Path is a required parameter'),
-	[Switch]$Front
+    [Switch]$Front
   )
   Begin
   {

--- a/local/EnvironmentPath.psm1
+++ b/local/EnvironmentPath.psm1
@@ -1,0 +1,32 @@
+Set-StrictMode -Version Latest
+##====--------------------------------------------------------------------====##
+
+<#
+.SYNOPSIS
+  Add to the front of the current environment PATH.
+#>
+function Add-EnvironmentPath {
+  [CmdletBinding(SupportsShouldProcess,ConfirmImpact='Medium')]
+  param(
+    [ValidateScript({ Test-Path -LiteralPath "$_" -PathType 'Container' })]
+    [ValidateNotNullOrEmpty()]
+    [String]$Path = $(throw 'Path is a required parameter'),
+	[Switch]$Front
+  )
+  Begin
+  {
+    Get-CommonFlagsCaller $PSCmdlet $ExecutionContext.SessionState
+  }
+  Process
+  {
+  }
+  End
+  {
+    if ($PSCmdlet.ShouldProcess('$env:PATH', ('add ' + $Path) )) {
+      $env:PATH = "${Path};$env:PATH"
+    }
+  }
+}
+##====--------------------------------------------------------------------====##
+
+Export-ModuleMember -Function Add-EnvironmentPath

--- a/local/Get-CommonFlagsCaller.Tests.ps1
+++ b/local/Get-CommonFlagsCaller.Tests.ps1
@@ -30,12 +30,12 @@ function Test-Calling {
 ##====--------------------------------------------------------------------====##
 Describe 'Get-CommonFlagsCaller' {
   It 'has documentation' {
-    Get-Help Invoke-Curl | Out-String |
+    Get-Help Get-CommonFlagsCaller | Out-String |
       Should -MatchExactly 'SYNOPSIS' -Because $msg_documentation
   }
-  It 'supports -WhatIf and -Confirm' {
-    Get-Command -Name Invoke-Curl -Syntax |
-      Should -Match '-WhatIf.*-Confirm'
+  It 'no support for -WhatIf and -Confirm' {
+    Get-Command -Name Get-CommonFlagsCaller -Syntax |
+      Should -not -Match '-WhatIf.*-Confirm'
   }
 
   Context 'Input Errors' {


### PR DESCRIPTION
Add the basics to handle installing and updating vcpkg, a C++ package manager.

**Features**
- Updates the default installed vcpkg version on AppVeyor.
- Handles caching to minimise rebuilds.
- With the flag `-Latest` rebuilds on changes to the tool source. (Advised by maintainers, but very frequent rebuilds.)
- Automatically updates any cached ports (packages).
- Support for using with a custom fixed state (`-FixedCommit <SHA1-hash>`).
- Black-listed build versions.
- Installs when not installed (new image).

**Not yet supported**
- `--overlay-ports`
- untested: multiple libraries
- port/ package installs
- ...

AppVeyorHelpers version: 0.12