### PR TITLE
Send-Codecov improvements

### DIFF
--- a/AppVeyor/Show-SystemInfo.psm1
+++ b/AppVeyor/Show-SystemInfo.psm1
@@ -92,7 +92,7 @@ function Show-SystemInfo {
         $((Get-CimInstance CIM_OperatingSystem).OSArchitecture)
       }
     )
-    # AppVeyor default matrix 
+    # AppVeyor default matrix
     if (Assert-CI -and $env:APPVEYOR_BUILD_WORKER_IMAGE) {
       $out += Join-Info 'Image' $env:APPVEYOR_BUILD_WORKER_IMAGE
     }

--- a/AppVeyorHelpers.psd1
+++ b/AppVeyorHelpers.psd1
@@ -7,7 +7,7 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = ''
-ModuleVersion = '0.11.0'
+ModuleVersion = '0.11.1'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/Codecov/Codecov.psd1
+++ b/Codecov/Codecov.psd1
@@ -1,7 +1,7 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = ''
-ModuleVersion = '0.4'
+ModuleVersion = '0.5'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/Codecov/Codecov.psd1
+++ b/Codecov/Codecov.psd1
@@ -1,7 +1,7 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = ''
-ModuleVersion = '0.3'
+ModuleVersion = '0.4'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/Codecov/Send-Codecov.psd1
+++ b/Codecov/Send-Codecov.psd1
@@ -7,12 +7,12 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = 'Send-Codecov.psm1'
-ModuleVersion = '0.3'
+ModuleVersion = '0.4'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'
 # CompanyName = 'Unknown'
-Description = ''
+Description = 'Single command coverage to codecov.io'
 # ID used to uniquely identify this module
 # GUID = 'd0a9150d-b6a4-4b17-a325-e3a24fed0aa9'
 # HelpInfoURI = ''

--- a/Codecov/Send-Codecov.psd1
+++ b/Codecov/Send-Codecov.psd1
@@ -7,7 +7,7 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = 'Send-Codecov.psm1'
-ModuleVersion = '0.4'
+ModuleVersion = '0.5'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/General/Expand-Archive.psm1
+++ b/General/Expand-Archive.psm1
@@ -23,7 +23,7 @@ Set-StrictMode -Version Latest
   Ignoring any internal directory structures.
 .EXAMPLE
   Expand-Archive large-archive.zip .\ -ShowProgress
-  
+
   For very large archives, taking a long time to extract, it is useful to
   display the progress indicator to prevent job cancellation due to inactivity.
 #>

--- a/General/Test-Command.psm1
+++ b/General/Test-Command.psm1
@@ -39,7 +39,7 @@ Set-StrictMode -Version Latest
   True
 .OUTPUTS
   A Boolean value is returned. True when execution succeeds without errors or
-  the output sting matches. 
+  the output sting matches.
   $LASTEXITCODE is always 0 after execution in Mode 1 (non-matching).
 .NOTES
   Not capable of containing $Hosts.SetShouldExit().


### PR DESCRIPTION
When using the AppVeyor setting `shallow_clone: true` there is no git repository in the working directory.
- Support usage from git repositories, not on AppVeyor, by supplying the Codecov Repository Token.
- Reorganised to conditionally set flags, allowing for more complex configurations (and future additions).
- Support setting multiple [flags](https://docs.codecov.io/docs/flags) on each upload.

Improved test coverage.