### PR TITLE
PSScriptAnalyzer

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,7 @@ skip_commits:
   files:
   - .git*
   - LICENSE
+  - PSScriptAnalyzerSettings.psd1
   - '**/*.md'
 
 cache:

--- a/AppVeyor/Send-Message.Tests.ps1
+++ b/AppVeyor/Send-Message.Tests.ps1
@@ -281,7 +281,7 @@ Describe 'Internal Stop-Execution' {
       Mock Assert-CI { return $true } -ModuleName Send-Message
 
       It 'WhatIf' {
-        { Stop-Execution -WhatIf -Message 'xX' } | Should -Throw 'xX' 
+        { Stop-Execution -WhatIf -Message 'xX' } | Should -Throw 'xX'
       }
     }
   }

--- a/AppVeyor/Send-Message.Tests.ps1
+++ b/AppVeyor/Send-Message.Tests.ps1
@@ -271,6 +271,23 @@ Describe 'Split-Text' {
 } # Split-Text
 
 ##====--------------------------------------------------------------------====##
+Describe 'Internal Stop-Execution' {
+  InModuleScope Send-Message {
+    It 'supports -WhatIf and -Confirm' {
+      Get-Command -Name Stop-Execution -Syntax |
+        Should -Match '-Whatif.*-Confirm'
+    }
+    Context 'CI' {
+      Mock Assert-CI { return $true } -ModuleName Send-Message
+
+      It 'WhatIf' {
+        { Stop-Execution -WhatIf -Message 'xX' } | Should -Throw 'xX' 
+      }
+    }
+  }
+} # Internal Stop-Execution
+
+##====--------------------------------------------------------------------====##
 Describe 'Send-Message' {
   It 'has documentation' {
     Get-Help Send-Message | Out-String |

--- a/AppVeyor/Send-Message.psm1
+++ b/AppVeyor/Send-Message.psm1
@@ -186,9 +186,12 @@ function Send-Message {
 ##====--------------------------------------------------------------------====##
 
 function Stop-Execution {
+  [CmdletBinding(SupportsShouldProcess,ConfirmImpact='None')]
   param($Message)
 
-  if (Assert-CI) { $Host.SetShouldExit(1) }
+  if ((Assert-CI) -and $PSCmdlet.ShouldProcess('Host.SetShouldExit')) {
+    $Host.SetShouldExit(1)
+  }
   throw $Message
 }
 ##====--------------------------------------------------------------------====##

--- a/AppVeyor/Send-TestResult.psm1
+++ b/AppVeyor/Send-TestResult.psm1
@@ -38,7 +38,7 @@ function Send-TestResult {
     }
     foreach ($FilePath in $ResolvedList) {
       Write-Verbose "Report: ${FilePath}"
-      if ( $(Get-Content -Raw -LiteralPath ($FilePath.Path) ) -eq $null ) {
+      if ( $null -eq $(Get-Content -Raw -LiteralPath ($FilePath.Path) ) ) {
         Send-Message -Warning `
           "$($MyInvocation.MyCommand): Skip, empty file: ${FilePath}"
         continue

--- a/AppVeyor/Show-SystemInfo.Tests.ps1
+++ b/AppVeyor/Show-SystemInfo.Tests.ps1
@@ -47,7 +47,7 @@ Describe 'Internal Join-Info' {
         (Join-Info 'some' 'text').Length | Should -Be 24 -Because '20+4'
         Join-Info 'some' 'text' |
           Should -MatchExactly 'some:               text' `
-          -Because 'default Length = 20'
+          -Because ('default Length = ' + $Align)
         Join-Info 'some' 'text' |
           Should -not -MatchExactly 'some:    text' -Because 'test-error'
       }
@@ -56,11 +56,13 @@ Describe 'Internal Join-Info' {
         Join-Info 'some' 'text' | Should -Match 'some:.*text'
         (Join-Info 'some' 'text').Length | Should -Be 21 -Because '17+4'
         Join-Info 'some' 'text' | Should -MatchExactly 'some:            text' `
-          -Because '$Align = 17'
+          -Because ('$Align = ' + $Align)
         Join-Info 'some' 'text' |
           Should -not -MatchExactly 'some:    text' -Because 'test-error'
       }
       It '-Name longer than (15-2=13) characters' {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+          'PSUseDeclaredVarsMoreThanAssignment', 'Align')]
         $Align = 15
         Join-Info '1234567890123' 'text' |
           Should -Match '1234567890123: text'
@@ -76,6 +78,8 @@ Describe 'Internal Join-Info' {
           Should -Be 36 -Because '30+2+4'
       }
       It 'align to different -Length' {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+          'PSUseDeclaredVarsMoreThanAssignment', 'Align')]
         $Align = 15
         Join-Info 'some' 'text' -Length 10 | Should -Match 'some:.*text'
         (Join-Info 'some' 'text' -Length 10).Length |

--- a/AppVeyor/Show-SystemInfo.psm1
+++ b/AppVeyor/Show-SystemInfo.psm1
@@ -86,13 +86,8 @@ function Show-SystemInfo {
     } else { $out += ('-- Local System Configuration --').PadRight(80,'-') }
     # System
     $out += Join-Info 'OS / platform' $(
-      if ($PSVersionTable.PSVersion.Major -lt 6) {
-        $((Get-WmiObject Win32_OperatingSystem).Caption) + ' / ' +
-        $((Get-WmiObject Win32_OperatingSystem).OSArchitecture)
-      } else {
-        $((Get-CimInstance CIM_OperatingSystem).Caption) + ' / ' +
-        $((Get-CimInstance CIM_OperatingSystem).OSArchitecture)
-      }
+      $((Get-CimInstance CIM_OperatingSystem).Caption) + ' / ' +
+      $((Get-CimInstance CIM_OperatingSystem).OSArchitecture)
     )
     # AppVeyor default matrix
     if (Assert-CI -and $env:APPVEYOR_BUILD_WORKER_IMAGE) {

--- a/C++/Install-Ninja.Tests.ps1
+++ b/C++/Install-Ninja.Tests.ps1
@@ -132,7 +132,7 @@ Describe 'Install-Ninja' {
        It 'no change in current working directory' {
          $PWD.Path | Should -Be $start_path.Path
        }
-       if ($PWD -ne $start_path) { cd $start_path }
+       if ($PWD -ne $start_path) { Set-Location $start_path }
     }
     Context 'AddToPath' {
       It 'Call with -WhatIf and -AddToPath' {
@@ -166,7 +166,7 @@ Describe 'Install-Ninja' {
       It 'no change in current working directory' {
         $PWD.Path | Should -Be $start_path.Path
       }
-      if ($PWD -ne $start_path) { cd $start_path }
+      if ($PWD -ne $start_path) { Set-Location $start_path }
       It 'no change in search path' {
         $env:Path | Should -Be $original_path
       }
@@ -483,7 +483,7 @@ Describe 'Install-Ninja (online)' -Tag 'online' {
     It 'no change in current working directory' {
       $PWD.Path | Should -Be $start_path.Path
     }
-    if ($PWD -ne $start_path) { cd $start_path }
+    if ($PWD -ne $start_path) { Set-Location $start_path }
   }
 
   $original_path = $env:Path
@@ -519,7 +519,7 @@ Describe 'Install-Ninja (online)' -Tag 'online' {
     It 'no change in current working directory' {
       $PWD.Path | Should -Be $start_path.Path
     }
-    if ($PWD -ne $start_path) { cd $start_path }
+    if ($PWD -ne $start_path) { Set-Location $start_path }
     Context 'path failure' {
       Mock Test-Command { return $false } -ModuleName Install-Ninja
 

--- a/C++/Install-Ninja.psm1
+++ b/C++/Install-Ninja.psm1
@@ -184,6 +184,7 @@ function Install-Ninja {
 ##====--------------------------------------------------------------------====##
 
 function Remove-Temporary {
+  [CmdletBinding(SupportsShouldProcess,ConfirmImpact='Medium')]
   param(
     [ValidatePattern('^[^\\\/\~]')]
     [ValidateScript({ "$_" -match (('^' + $env:TEMP) -replace '\\','\\') })]

--- a/C++/Update-Vcpkg.Tests.ps1
+++ b/C++/Update-Vcpkg.Tests.ps1
@@ -4,8 +4,6 @@ Set-StrictMode -Version Latest
 
 ##====--------------------------------------------------------------------====##
 $global:msg_documentation = 'at least 1 empty line above documentation'
-$default_cache_dir = Join-Path (Join-Path (Join-Path $HOME 'Tools') 'cache'
-  ) 'vcpkg'
 
 if (Assert-CI) {
   # Prevent warnings on AppVeyor.
@@ -289,10 +287,11 @@ Describe 'Internal Test-ChangedVcpkgSource' {
     Context '$cache_dir defined' {
       $hash_file = Join-Path $PSScriptRoot 'vcpkg_source.hash'
       $cache_dir = Join-Path 'TestDrive:\' 'cache'
-      $cached_file = Join-Path $cache_dir 'vcpkg_source.hash'
 
       # Helper function
       function Invoke-Test {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+          'PSUseDeclaredVarsMoreThanAssignment', 'cache_dir')]
         $cache_dir = Join-Path 'TestDrive:\' 'cache'
         Test-ChangedVcpkgSource
       }
@@ -351,21 +350,31 @@ Describe 'Internal Import-CachedVcpkg' {
       Mock Assert-CI { return $true } -ModuleName 'Update-Vcpkg'
 
       { Import-CachedVcpkg 2>$null } | Should -Throw
+      [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseDeclaredVarsMoreThanAssignment', 'cache_dir')]
       $cached_dir = 'TestDrive:\'
       { Import-CachedVcpkg 2>$null } | Should -Throw
       $cached_dir = ''
+      [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseDeclaredVarsMoreThanAssignment', 'Location')]
       $Location = 'TestDrive:\'
       { Import-CachedVcpkg 2>$null } | Should -Throw
     }
 
     Context 'WhatIf' {
       Mock Assert-CI { return $true } -ModuleName 'Update-Vcpkg'
+      [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseDeclaredVarsMoreThanAssignment', 'cache_dir')]
       $cache_dir = 'TestDrive:\cache'
       $target_dir = 'TestDrive:\target'
       New-Item -Path $target_dir -ItemType Directory
       New-Item -Path $cache_dir -ItemType Directory
       function Invoke-Import {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+          'PSUseDeclaredVarsMoreThanAssignment', 'cache_dir')]
         $cache_dir = 'TestDrive:\cache'
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+          'PSUseDeclaredVarsMoreThanAssignment', 'Location')]
         $Location = 'TestDrive:\target'
         return (Import-CachedVcpkg -WhatIf)
       }
@@ -391,11 +400,17 @@ Describe 'Internal Import-CachedVcpkg' {
 
     Context '$cache_dir defined' {
       Mock Assert-CI { return $true } -ModuleName 'Update-Vcpkg'
+      [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseDeclaredVarsMoreThanAssignment', 'cache_dir')]
       $cache_dir = 'TestDrive:\cache 1'
       $target_dir = 'TestDrive:\target 1'
       New-Item -Path $target_dir -ItemType Directory
       function Invoke-Import {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+          'PSUseDeclaredVarsMoreThanAssignment', 'cache_dir')]
         $cache_dir = 'TestDrive:\cache 1'
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+          'PSUseDeclaredVarsMoreThanAssignment', 'Location')]
         $Location = 'TestDrive:\target 1'
         return Import-CachedVcpkg
       }
@@ -508,11 +523,15 @@ Describe 'Internal Export-CachedVcpkg' {
 
     Context 'WhatIf' {
       Mock Assert-CI { return $true } -ModuleName 'Update-Vcpkg'
+      [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseDeclaredVarsMoreThanAssignment', 'cache_dir')]
       $cache_dir = 'TestDrive:\cache'
       $vcpkg_dir = 'TestDrive:\vcpkg'
       New-Item -Path $vcpkg_dir -ItemType Directory
       New-Item -Path $cache_dir -ItemType Directory
       function Invoke-Export {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+          'PSUseDeclaredVarsMoreThanAssignment', 'cache_dir')]
         $cache_dir = 'TestDrive:\cache'
         return (Export-CachedVcpkg -WhatIf)
       }
@@ -539,10 +558,14 @@ Describe 'Internal Export-CachedVcpkg' {
 
     Context '$cache_dir defined' {
       Mock Assert-CI { return $true } -ModuleName 'Update-Vcpkg'
+      [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseDeclaredVarsMoreThanAssignment', 'cache_dir')]
       $cache_dir = 'TestDrive:\cache 1'
       $vcpkg_dir = 'TestDrive:\vcpkg dir'
       New-Item -Path $vcpkg_dir -ItemType Directory
       function Invoke-Export {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+          'PSUseDeclaredVarsMoreThanAssignment', 'cache_dir')]
         $cache_dir = 'TestDrive:\cache 1'
         return Export-CachedVcpkg
       }
@@ -812,6 +835,8 @@ Describe 'Update-Vcpkg' {
     $vcpkg_dir = New-Item -Path 'TestDrive:\' -Name 'vc 1' -ItemType Directory
     It '-Path (existing) clone & merge' {
       Assert-VcpkgRequirements
+      [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseDeclaredVarsMoreThanAssignment', 'vcpkg_dir')]
       $path = Join-Path $vcpkg_dir 'vcpkg'
       { Update-Vcpkg -Path $vcpkg_dir -WhatIf *>$null } |
         Should -not -Throw
@@ -825,6 +850,8 @@ Describe 'Update-Vcpkg' {
     $vcpkg_dir = Join-Path (Join-Path 'TestDrive:\' 'vc 2') 'vcpkg'
     It '-Path (non-existing) - creates directory' {
       Assert-VcpkgRequirements
+      [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseDeclaredVarsMoreThanAssignment', 'vcpkg_dir')]
       $path = Join-Path $vcpkg_dir 'vcpkg'
       { Update-Vcpkg -Path $vcpkg_dir -Quiet -WhatIf *>$null } |
         Should -not -Throw
@@ -838,6 +865,8 @@ Describe 'Update-Vcpkg' {
     $vcpkg_dir = New-Item -Path 'TestDrive:\' -Name 'vc 3' -ItemType Directory
     It '-FixedCommit: clone & checkout' {
       Assert-VcpkgRequirements
+      [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseDeclaredVarsMoreThanAssignment', 'vcpkg_dir')]
       $path = Join-Path $vcpkg_dir 'vcpkg'
       { Update-Vcpkg -Path $vcpkg_dir `
         -FixedCommit CF83E1357000000DF1542850D66D8007D620E405 -Quiet -WhatIf `

--- a/C++/Update-Vcpkg.Tests.ps1
+++ b/C++/Update-Vcpkg.Tests.ps1
@@ -706,7 +706,7 @@ Describe 'Internal Update-Repository' {
 }
 
 ##====--------------------------------------------------------------------====##
-function Assert-VcpkgRequirements {
+function Assert-RequirementsVcpkg {
   if ($env:APPVEYOR_BUILD_WORKER_IMAGE -match 'Visual Studio 2013') {
     Set-ItResult -Skipped -Because 'not supported for VS2013'
   }
@@ -780,7 +780,7 @@ Describe 'Update-Vcpkg' {
         New-Item -Path $path -ItemType Directory
         New-Item -Path $path -Name 'somefile.txt' -ItemType File
         It 'throw: non-empty, not a git working directory' {
-          Assert-VcpkgRequirements
+          Assert-RequirementsVcpkg
           { Update-vcpkg -Path $path 3>$null 6>$null } |
             Should -Throw 'not empty and not a git working directory'
           if (Assert-CI) {
@@ -816,7 +816,7 @@ Describe 'Update-Vcpkg' {
     }
     $cache = New-Item -Path 'TestDrive:\' -name 'some_cache' -ItemType Container
     It 'warning from -CachePath' {
-      Assert-VcpkgRequirements
+      Assert-RequirementsVcpkg
       Mock Assert-CI { return $false } -ModuleName Update-Vcpkg
       (Update-Vcpkg -CachePath $cache -WhatIf 6>$null) 3>&1 |
         Should -Match 'CachePath has no use outside the AppVeyor environment'
@@ -834,7 +834,7 @@ Describe 'Update-Vcpkg' {
     # clone / merge
     $vcpkg_dir = New-Item -Path 'TestDrive:\' -Name 'vc 1' -ItemType Directory
     It '-Path (existing) clone & merge' {
-      Assert-VcpkgRequirements
+      Assert-RequirementsVcpkg
       [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSUseDeclaredVarsMoreThanAssignment', 'vcpkg_dir')]
       $path = Join-Path $vcpkg_dir 'vcpkg'
@@ -849,7 +849,7 @@ Describe 'Update-Vcpkg' {
     }
     $vcpkg_dir = Join-Path (Join-Path 'TestDrive:\' 'vc 2') 'vcpkg'
     It '-Path (non-existing) - creates directory' {
-      Assert-VcpkgRequirements
+      Assert-RequirementsVcpkg
       [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSUseDeclaredVarsMoreThanAssignment', 'vcpkg_dir')]
       $path = Join-Path $vcpkg_dir 'vcpkg'
@@ -864,7 +864,7 @@ Describe 'Update-Vcpkg' {
     # clone / checkout
     $vcpkg_dir = New-Item -Path 'TestDrive:\' -Name 'vc 3' -ItemType Directory
     It '-FixedCommit: clone & checkout' {
-      Assert-VcpkgRequirements
+      Assert-RequirementsVcpkg
       [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSUseDeclaredVarsMoreThanAssignment', 'vcpkg_dir')]
       $path = Join-Path $vcpkg_dir 'vcpkg'
@@ -897,7 +897,7 @@ Describe 'Update-Vcpkg' {
     $vcpkg_dir = New-Item -Path 'TestDrive:\' -Name 'loc' -ItemType Directory
 
     It 'no changes with -Latest -WhatIf' {
-      Assert-VcpkgRequirements
+      Assert-RequirementsVcpkg
       if (-not (Test-Command 'vcpkg version')) {
         Set-ItResult -Skipped -Because 'requires installed vcpkg'
       }
@@ -932,7 +932,7 @@ Describe 'Update-Vcpkg' {
     ) > (Join-Path $vcpkg_dir 'vcpkg.ps1')
 
     It 'build after retrieval from cache (mocked)' {
-      Assert-VcpkgRequirements
+      Assert-RequirementsVcpkg
       { Update-Vcpkg -Path $vcpkg_dir -Quiet -WhatIf 3>$null } |
         Should -not -Throw
       Assert-MockCalled -CommandName Update-Repository `
@@ -945,7 +945,7 @@ Describe 'Update-Vcpkg' {
     }
     Mock Test-IfReleaseWithIssues { return $false } -ModuleName Update-Vcpkg
     It 'no build after retrieval from cache (mocked)' {
-      Assert-VcpkgRequirements
+      Assert-RequirementsVcpkg
       { Update-Vcpkg -Path $vcpkg_dir -Quiet -WhatIf 3>$null } |
         Should -not -Throw
       Assert-MockCalled -CommandName Update-Repository `
@@ -983,7 +983,7 @@ Describe 'Update-Vcpkg' {
     ) > (Join-Path $vcpkg_dir 'vcpkg.ps1')
 
     It 'vcpkg is up-to-date' {
-      Assert-VcpkgRequirements
+      Assert-RequirementsVcpkg
       { Update-Vcpkg -Path $vcpkg_dir -Quiet -Verbose -WhatIf 4>$null } |
         Should -not -Throw
       Assert-MockCalled -CommandName Update-Repository `
@@ -1007,7 +1007,7 @@ Describe 'Update-Vcpkg' {
   }
   $original_CI_WINDOWS = $env:CI_WINDOWS
   It 'failed build' {
-    Assert-VcpkgRequirements # not for image: Visual Studio 2013
+    Assert-RequirementsVcpkg # not for image: Visual Studio 2013
     Mock Push-Location { throw 'something' } -ModuleName Update-vcpkg
     Mock Assert-CI { return $true } -ModuleName Update-vcpkg
     Mock Test-Path { return $false } -ModuleName Update-vcpkg

--- a/Codecov/Assert-ValidCodecovYML.psm1
+++ b/Codecov/Assert-ValidCodecovYML.psm1
@@ -53,7 +53,7 @@ function Assert-ValidCodecovYML {
     }
     Write-Verbose ('Resolved path: ' + $Path[0].Path)
     $content = Get-Content -Raw -LiteralPath ($Path[0].Path)
-    if ($content -eq $null ) {
+    if ($null -eq $content) {
       Send-Message -Error -Message "$($MyInvocation.MyCommand): Empty File"
     }
     $Uri = 'https://codecov.io/validate'
@@ -66,7 +66,7 @@ function Assert-ValidCodecovYML {
           $output = Invoke-RestMethod -Uri $Uri `
             -Body (Get-Content -Raw -LiteralPath ($Path[0].Path)) -Method POST
         } catch [System.Net.WebException] {
-          if ($_.Exception.Response -eq $null) {
+          if ($null -eq $_.Exception.Response) {
             Send-Message -Warning ('Failed to connect to "' + $Uri + '"!') `
               -Details ($_).ToString().Trim()
             return $null

--- a/Codecov/Send-Codecov.Tests.ps1
+++ b/Codecov/Send-Codecov.Tests.ps1
@@ -7,33 +7,33 @@ $global:msg_documentation = 'at least 1 empty line above documentation'
 $global:Codecov_token = 'd6c1c65d-1656-4321-a080-e0a0eee9a613'
 
 ##====--------------------------------------------------------------------====##
-Describe 'Internal Check-Installed' {
+Describe 'Internal Assert-CodecovInstalled' {
   InModuleScope Send-Codecov {
     It 'has documentation' {
-      Get-Help Check-Installed | Out-String |
+      Get-Help Assert-CodecovInstalled | Out-String |
         Should -MatchExactly 'SYNOPSIS' -Because $msg_documentation
     }
     Context 'Test-Command: $false; uploader is not installed' {
       Mock Test-Command { return $false } -ModuleName Send-Codecov
 
       $script:CodecovInstalled = $true
-      It 'Check-Installed variable $true, skip expensive test' {
-        Check-Installed | Should -BeTrue
-        Check-Installed | Should -BeOfType System.Boolean
+      It 'Assert-CodecovInstalled variable $true, skip expensive test' {
+        Assert-CodecovInstalled | Should -BeTrue
+        Assert-CodecovInstalled | Should -BeOfType System.Boolean
       }
       $script:CodecovInstalled = $false
-      It 'Check-Installed failure' {
-        Check-Installed | Should -BeFalse
+      It 'Assert-CodecovInstalled failure' {
+        Assert-CodecovInstalled | Should -BeFalse
       }
     }
     Context 'Test-Command: $true; uploader is installed' {
       Mock Test-Command { return $true } -ModuleName Send-Codecov
 
       $script:CodecovInstalled = $false
-      It 'Check-Installed returns $true' {
-        Check-Installed | Should -BeTrue
+      It 'Assert-CodecovInstalled returns $true' {
+        Assert-CodecovInstalled | Should -BeTrue
       }
-      It 'Check-Installed sets $global:CodecovInstalled' {
+      It 'Assert-CodecovInstalled sets $global:CodecovInstalled' {
         $CodecovInstalled | Should -BeTrue
       }
     }
@@ -59,14 +59,14 @@ Describe 'Internal Install-Uploader' {
     It 'Install-Uploader' {
       { Install-Uploader 2>$null } | Should -Not -Throw
     }
-    It 'tests Check-Installed (install succeeded)' {
-      Check-Installed | Should -BeTrue
+    It 'tests Assert-CodecovInstalled (install succeeded)' {
+      Assert-CodecovInstalled | Should -BeTrue
     }
 
-    Context 'Mock: Check-Installed' {
+    Context 'Mock: Assert-CodecovInstalled' {
       [Int]$script:counter = 0
       [Int]$script:first_true = 2
-      Mock Check-Installed {
+      Mock Assert-CodecovInstalled {
         $script:counter += 1
         if ($counter -lt $first_true) { return $false }
         else { return $true }
@@ -78,7 +78,7 @@ Describe 'Internal Install-Uploader' {
         $script:counter = 0
         $script:first_true = 1
         { Install-Uploader } | Should -not -Throw
-        Assert-MockCalled Check-Installed -Exactly 1 -Scope It
+        Assert-MockCalled Assert-CodecovInstalled -Exactly 1 -Scope It
         $script:counter = 0
         Install-Uploader | Should -Be $null
         $script:counter = 0
@@ -112,43 +112,43 @@ Describe 'Internal Install-Uploader' {
         $script:counter = 0
         $script:first_true = 1000
         { Install-Uploader 2>$null 6>&1 } | Should -Throw
-        Assert-MockCalled Check-Installed -Exactly 3 -Scope It
+        Assert-MockCalled Assert-CodecovInstalled -Exactly 3 -Scope It
       }
       It '-WhatIf, no throw; no installation' {
         $script:counter = 0
         $script:first_true = 1000
         { Install-Uploader -Whatif } | Should -not -Throw
-        Assert-MockCalled Check-Installed -Exactly 1 -Scope It
+        Assert-MockCalled Assert-CodecovInstalled -Exactly 1 -Scope It
       }
     }
   }
 }
 
 ##====--------------------------------------------------------------------====##
-Describe 'Internal Correct-BuildName' {
+Describe 'Internal Format-BuildName' {
   InModuleScope Send-Codecov {
     It 'has documentation' {
-      Get-Help Correct-BuildName | Out-String |
+      Get-Help Format-BuildName | Out-String |
         Should -MatchExactly 'SYNOPSIS' -Because $msg_documentation
     }
     It 'BuildName input required' {
-      { Correct-BuildName } | Should -Throw 'BuildName is required'
+      { Format-BuildName } | Should -Throw 'BuildName is required'
     }
     It 'trim white-space' {
-      Correct-BuildName '  Begin' | Should -MatchExactly 'Begin'
-      Correct-BuildName 'End   ' | Should -MatchExactly 'End'
-      Correct-BuildName "`tBegin" | Should -MatchExactly 'Begin'
-      Correct-BuildName "End`t`t" | Should -MatchExactly 'End'
+      Format-BuildName '  Begin' | Should -MatchExactly 'Begin'
+      Format-BuildName 'End   ' | Should -MatchExactly 'End'
+      Format-BuildName "`tBegin" | Should -MatchExactly 'Begin'
+      Format-BuildName "End`t`t" | Should -MatchExactly 'End'
     }
     It 'replace spaces' {
-      Correct-BuildName 'In Between    These' |
+      Format-BuildName 'In Between    These' |
         Should -MatchExactly 'In_Between_These'
-      Correct-BuildName 'Name Like This' | Should -MatchExactly 'Name_Like_This'
+      Format-BuildName 'Name Like This' | Should -MatchExactly 'Name_Like_This'
     }
     It 'replace tabs' {
-      Correct-BuildName "In`tBetween" | Should -MatchExactly 'In_Between'
-      Correct-BuildName "In`t`tBetween" | Should -MatchExactly 'In_Between'
-      Correct-BuildName "In`t `tBetween" | Should -MatchExactly 'In_Between'
+      Format-BuildName "In`tBetween" | Should -MatchExactly 'In_Between'
+      Format-BuildName "In`t`tBetween" | Should -MatchExactly 'In_Between'
+      Format-BuildName "In`t `tBetween" | Should -MatchExactly 'In_Between'
     }
   }
 }
@@ -235,7 +235,7 @@ Describe 'Internal Send-Report' {
 
 ##====--------------------------------------------------------------------====##
 
-function Require-CodecovInstalled {
+function Assert-CodecovInstalled {
   if (-not $global:CodecovInstalled) {
     Set-ItResult -Inconclusive -Because 'Install failure codecov uploader.'
   }
@@ -273,24 +273,24 @@ Describe 'Send-Codecov' {
         Should -Throw 'argument is null or empty'
     }
     It 'throws on invalid pattern (single path)' {
-      Require-CodecovInstalled
+      Assert-CodecovInstalled
       { Send-Codecov -Path 'report.html' -BuildName build 6>$null } |
         Should -Throw 'invalid pattern'
     }
     It 'no throw on invalid pattern (multiple paths)' {
-      Require-CodecovInstalled
+      Assert-CodecovInstalled
       { Send-Codecov -Path @('report.html','ahaXml') -BuildName build 6>$null
       } | Should -Not -Throw
       Send-Codecov -Path @('report.html','ahaXml') -BuildName build 6>&1 |
         Should -Match 'Invalid pattern'
     }
     It 'throws on non-existing file (single path)' {
-      Require-CodecovInstalled
+      Assert-CodecovInstalled
       { Send-Codecov -Path 'report.xml' -BuildName build 6>$null } |
         Should -Throw 'invalid path'
     }
     It 'no throw on non-existing file (multiple paths)' {
-      Require-CodecovInstalled
+      Assert-CodecovInstalled
       { Send-Codecov -Path @('report.xml','report2.xml') -BuildName build `
         6>$null
       } | Should -Not -Throw
@@ -300,7 +300,7 @@ Describe 'Send-Codecov' {
     In TestDrive:\ {
       New-Item -Path . -Name report.xml
       It 'non-existing file (multiple paths)' {
-        Require-CodecovInstalled
+        Assert-CodecovInstalled
         { Send-Codecov -Path @('report.xml','report2.xml') -BuildName build `
           3>$null 6>$null
         } | Should -Not -Throw
@@ -308,7 +308,7 @@ Describe 'Send-Codecov' {
           3>$null 6>&1 | Should -Match 'Invalid path'
       }
       It 'skips on empty file' {
-        Require-CodecovInstalled
+        Assert-CodecovInstalled
         { Send-Codecov -Path 'report.xml' -BuildName build 3>$null } |
           Should -Not -Throw
         Send-Codecov -Path 'report.xml' -BuildName build 3>&1 |
@@ -316,22 +316,22 @@ Describe 'Send-Codecov' {
       }
       'text to fill file' > report.xml
       It 'valid call' {
-        Require-CodecovInstalled
+        Assert-CodecovInstalled
         Send-Codecov -Path 'report.xml' -BuildName build |
           Should -Match '.*[\\/]report\.xml$'
       }
       It 'wild card characters' {
-        Require-CodecovInstalled
+        Assert-CodecovInstalled
         Send-Codecov -Path 'r*.xml' -BuildName build |
           Should -Match '.*[\\/]report\.xml$'
       }
       It 'wild card characters 2' {
-        Require-CodecovInstalled
+        Assert-CodecovInstalled
         Send-Codecov -Path 'r?port.xml' -BuildName build |
           Should -Match '.*[\\/]report\.xml$'
       }
       It 'Path separators' {
-        Require-CodecovInstalled
+        Assert-CodecovInstalled
         Send-Codecov -Path './report.xml' -BuildName build |
           Should -Match '.*[\\/]report\.xml$'
         Send-Codecov -Path '.\report.xml' -BuildName build |
@@ -381,12 +381,12 @@ Describe 'Send-Codecov' {
         Should -Throw 'argument is null or empty'
     }
     It 'valid call' {
-      Require-CodecovInstalled
+      Assert-CodecovInstalled
       Send-Codecov 'TestDrive:\report.xml' -BuildName 'Name Like This 3' |
         Should -MatchExactly 'Name_Like_This_3'
     }
     It 'valid call (with -Flag)' {
-      Require-CodecovInstalled
+      Assert-CodecovInstalled
       Send-Codecov 'TestDrive:\report.xml' -BuildName 'Name Like This 3' `
         -Flag unit_tests_2 | Should -MatchExactly 'Name_Like_This_3'
     }
@@ -424,7 +424,7 @@ Describe 'Send-Codecov' {
       } | Should -not -Throw
     }
     It 'Flags has a maximum length of 45 characters' {
-      Require-CodecovInstalled
+      Assert-CodecovInstalled
       { Send-Codecov 'TestDrive:\report.xml' -BuildName build `
         -Flags 'abcdefghijklmnopqrstuvwxyz0123456789_abcdefgh'
       } | Should -Not -Throw
@@ -435,7 +435,7 @@ Describe 'Send-Codecov' {
         -Scope It
     }
     It 'valid call' {
-      Require-CodecovInstalled
+      Assert-CodecovInstalled
       Send-Codecov 'TestDrive:\report.xml' -BuildName build `
         -Flags unit_tests_2 | Should -MatchExactly 'unit_tests_2'
       Assert-MockCalled Send-Report -ModuleName Send-Codecov -Exactly 1 `
@@ -474,17 +474,17 @@ Describe 'Send-Codecov' {
     New-Item -Path TestDrive: -Name report.xml
     'text' > TestDrive:\report.xml
     It 'Path alias: Report' {
-      Require-CodecovInstalled
+      Assert-CodecovInstalled
       Send-Codecov -Report 'TestDrive:\report.xml' -BuildName build |
         Should -Match 'report.xml'
     }
     It 'Path alias: File' {
-      Require-CodecovInstalled
+      Assert-CodecovInstalled
       Send-Codecov -File 'TestDrive:\Report.xml' -BuildName build |
         Should -Match 'report.xml'
     }
     It 'Path alias: FileName' {
-      Require-CodecovInstalled
+      Assert-CodecovInstalled
       Send-Codecov -FileName 'TestDrive:\report.xml' -BuildName build |
         Should -Match 'report.xml'
     }

--- a/Codecov/Send-Codecov.psm1
+++ b/Codecov/Send-Codecov.psm1
@@ -68,7 +68,7 @@ function Send-Codecov {
   {
     Get-CommonFlagsCaller $PSCmdlet $ExecutionContext.SessionState
 
-    $BuildName = Correct-BuildName($BuildName)
+    $BuildName = Format-BuildName($BuildName)
     Write-Verbose "BuildName: $BuildName"
     if ($Flags) {
       $wrong = @()
@@ -143,7 +143,7 @@ function Send-Codecov {
   The test is expensive, so the result is cached in the global variable
   `CodecovInstalled`.
 #>
-function Check-Installed {
+function Assert-CodecovInstalled {
   [CmdletBinding()]
   param()
   Get-CommonFlagsCaller $PSCmdlet $ExecutionContext.SessionState
@@ -167,17 +167,17 @@ function Install-Uploader {
   param()
   Get-CommonFlagsCaller $PSCmdlet $ExecutionContext.SessionState
 
-  if ($(Check-Installed)) { return }
+  if ($(Assert-CodecovInstalled)) { return }
   if ($PSCmdlet.ShouldProcess(
     'Installing Codecov uploader ...', # Verbose/ WhatIf
     'Are you sure you want to run "pip install codecov" on this system?',
     'Install Codecov uploader') # Caption
   ) {
     $(pip --disable-pip-version-check -qq install codecov)
-    if (-not $(Check-Installed)) {
+    if (-not $(Assert-CodecovInstalled)) {
       Write-Verbose 'Retry in user profile ...'
       $(pip --disable-pip-version-check -qq install codecov --user)
-      if (-not $(Check-Installed)) {
+      if (-not $(Assert-CodecovInstalled)) {
         $(pip --disable-pip-version-check install codecov) |
           Send-Message -Error 'Installing Codecov uploader failed.'
       }
@@ -194,7 +194,7 @@ function Install-Uploader {
   Strip leading/trailing white-space.
   Replace any white space with a single underscore. (Codecov)
 #>
-function Correct-BuildName {
+function Format-BuildName {
   param(
     [String]$BuildName = $(throw '-BuildName is required')
   )

--- a/Codecov/Send-Codecov.psm1
+++ b/Codecov/Send-Codecov.psm1
@@ -153,7 +153,7 @@ function Assert-CodecovInstalled {
     if ( Test-Command -Command 'python -c "import codecov"' ) {
       Set-Variable -Name CodecovInstalled -Value $true -Scope Global
     } else { return $false }
-  } 
+  }
   return $true
 }
 ##====--------------------------------------------------------------------====##

--- a/Codecov/Send-Codecov.psm1
+++ b/Codecov/Send-Codecov.psm1
@@ -145,6 +145,7 @@ function Send-Codecov {
 #>
 function Assert-CodecovInstalled {
   [CmdletBinding()]
+  [OutputType([Bool])]
   param()
   Get-CommonFlagsCaller $PSCmdlet $ExecutionContext.SessionState
 

--- a/Codecov/Send-Codecov.psm1
+++ b/Codecov/Send-Codecov.psm1
@@ -120,7 +120,7 @@ function Send-Codecov {
       }
       foreach ($FilePath in $ResolvedList) {
         Write-Verbose "Report: ${FilePath}"
-        if ( $(Get-Content -Raw -LiteralPath ($FilePath.Path) ) -eq $null ) {
+        if ($null -eq $(Get-Content -Raw -LiteralPath ($FilePath.Path) ) ) {
           Send-Message -Warning -Message `
             "$($MyInvocation.MyCommand): Skip, empty file: ${FilePath}"
           continue

--- a/General/Convert-FileEncoding.Tests.ps1
+++ b/General/Convert-FileEncoding.Tests.ps1
@@ -261,6 +261,8 @@ Describe 'Internal Convert-EOL' {
           Should -Throw 'Unknown LineEnding input'
       }
       It 'Should not throw on valid input' {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+          'PSUseDeclaredVarsMoreThanAssignment', 'SourcePath')]
         $SourcePath = 'placeholder'
         { Convert-EOL 'some text' -LineEnding Unix } | Should -Not -Throw
         { Convert-EOL 'some text' -LineEnding LF } | Should -Not -Throw
@@ -270,6 +272,8 @@ Describe 'Internal Convert-EOL' {
       }
     }
     Context 'Operation' {
+      [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseDeclaredVarsMoreThanAssignment', 'SourcePath')]
       $SourcePath = 'placeholder'
       It 'no newline characters' {
         Convert-EOL 'no new-line characters' Unix |
@@ -341,12 +345,16 @@ Describe 'Internal Convert-EOL' {
       }
     }
     Context '-WhatIf' {
+      [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseDeclaredVarsMoreThanAssignment', 'SourcePath')]
       $SourcePath = 'placeholder'
       It 'CR to CRLF' {
         Convert-EOL "last`r" Windows -WhatIf | Should -BeExactly "last`r"
       }
     }
     Context 'Input from pipeline' {
+      [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseDeclaredVarsMoreThanAssignment', 'SourcePath')]
       $SourcePath = 'placeholder'
       It 'Do not throw for -Text from pipeline' {
         { 'some text' | Convert-EOL -LineEnding LF } |

--- a/General/Convert-FileEncoding.psm1
+++ b/General/Convert-FileEncoding.psm1
@@ -17,7 +17,7 @@ Set-StrictMode -Version Latest
   3. LineEnding: Windows is equivalent to CRLF and Unix is equivalent to LF.
 .EXAMPLE
   Convert-FileEncoding '.\*.md'
-  
+
   All markdown files in the current directory are converted to use UTF-8
   without a byte-order-mark. This is the default behaviour. Equivalent to:
   Convert-FileEncoding -SourcePath '.\*.md' -Encoding UTF8NoBOM

--- a/General/Expand-Archive.Tests.ps1
+++ b/General/Expand-Archive.Tests.ps1
@@ -227,7 +227,8 @@ Describe 'Expand-Archive' {
         if ( $PSVersionTable.PSVersion.Major -lt 6 ) {
           $file = [IO.Path]::Combine("$test_drive", $archive_name, $file_1)
         } else {
-          $file = Join-Path "$test_drive" $archive_name $file_1
+          $file = Join-Path -Path "$test_drive" -ChildPath $archive_name `
+            -AdditionalChildPath $file_1
         }
         Test-Path $file | Should -Be $true
       }
@@ -336,7 +337,8 @@ Describe 'Expand-Archive' {
         if ( $PSVersionTable.PSVersion.Major -lt 6 ) {
           $file = [IO.Path]::Combine("$test_drive", $archive_name, $dir_file)
         } else {
-          $file = Join-Path "$test_drive" $archive_name $dir_file
+          $file = Join-Path -Path "$test_drive" -ChildPath $archive_name `
+            -AdditionalChildPath $dir_file
         }
         Test-Path $file | Should -Be $true
       }

--- a/General/Expand-Archive.Tests.ps1
+++ b/General/Expand-Archive.Tests.ps1
@@ -18,7 +18,7 @@ function Test-InconclusiveMissingFile {
   } elseif ($Not -and (Test-Path "$Path" -PathType Leaf) ) {
     Set-ItResult -Inconclusive -Because ('should not exist: ' + "$Path")
   }
-} 
+}
 ##====--------------------------------------------------------------------====##
 
 Describe 'Expand-Archive' {

--- a/General/Invoke-Curl.Tests.ps1
+++ b/General/Invoke-Curl.Tests.ps1
@@ -126,7 +126,7 @@ Describe 'Invoke-Curl (offline)' {
     It 'no change in current working directory' {
       $PWD.Path | Should -Be $start_path.Path
     }
-    if ($PWD -ne $start_path) { cd $start_path }
+    if ($PWD -ne $start_path) { Set-Location $start_path }
 
     It 'download image.zip to a specific file name' {
       { Invoke-Curl -URL $Url -OutPath 'TestDrive:\dir2\file.zip' -WhatIf } |
@@ -141,7 +141,7 @@ Describe 'Invoke-Curl (offline)' {
     It 'no change in current working directory' {
       $PWD.Path | Should -Be $start_path.Path
     }
-    if ($PWD -ne $start_path) { cd $start_path }
+    if ($PWD -ne $start_path) { Set-Location $start_path }
   }
 }
 
@@ -170,7 +170,7 @@ Describe 'Invoke-Curl (online)' -Tag 'online' {
     It 'no change in current working directory' {
       $PWD.Path | Should -Be $start_path.Path
     }
-    if ($PWD -ne $start_path) { cd $start_path }
+    if ($PWD -ne $start_path) { Set-Location $start_path }
     It 'download image.zip to a specific file name' {
       { Invoke-Curl -URL $Url -OutPath 'TestDrive:\file.zip' } |
         Should -not -Throw
@@ -186,7 +186,7 @@ Describe 'Invoke-Curl (online)' -Tag 'online' {
     It 'no change in current working directory' {
       $PWD.Path | Should -Be $start_path.Path
     }
-    if ($PWD -ne $start_path) { cd $start_path }
+    if ($PWD -ne $start_path) { Set-Location $start_path }
     It 'download image.zip to a specific path' {
       { Invoke-Curl -URL $Url -OutPath 'TestDrive:\dir\file.zip' } |
         Should -not -Throw
@@ -207,7 +207,7 @@ Describe 'Invoke-Curl (online)' -Tag 'online' {
     It 'no change in current working directory' {
       $PWD.Path | Should -Be $start_path.Path
     }
-    if ($PWD -ne $start_path) { cd $start_path }
+    if ($PWD -ne $start_path) { Set-Location $start_path }
   }
 
   Context 'download failures' {
@@ -244,7 +244,7 @@ Describe 'Invoke-Curl (online)' -Tag 'online' {
     It 'no change in current working directory' {
       $PWD.Path | Should -Be $start_path.Path
     }
-    if ($PWD -ne $start_path) { cd $start_path }
+    if ($PWD -ne $start_path) { Set-Location $start_path }
   }
 
 }

--- a/General/Invoke-Curl.psm1
+++ b/General/Invoke-Curl.psm1
@@ -62,7 +62,7 @@ function Invoke-Curl {
       "--retry-max-time $RetryTimeout"
     )
     if (Test-Path -LiteralPath $OutPath -PathType Container) {
-      pushd $OutPath
+      Push-Location $OutPath
       $flags += @(
         '--remote-name'  # -O, Write output to a file named as the remote file.
       )
@@ -73,7 +73,7 @@ function Invoke-Curl {
         $OutPath = $OutPath -replace '^TestDrive:\\',
           (Resolve-Path TestDrive:\).ProviderPath
       }
-      pushd $pwd
+      Push-Location $pwd
       $flags += @(
         '--create-dirs', # Create necessary local directory hierarchy.
         '--output', "`"$OutPath`"" # -o, Write to file.
@@ -103,7 +103,7 @@ function Invoke-Curl {
   }
   End
   {
-    popd
+    Pop-Location
   }
 } #/ function Invoke-Curl
 ##====--------------------------------------------------------------------====##

--- a/General/Test-Command.Tests.ps1
+++ b/General/Test-Command.Tests.ps1
@@ -37,7 +37,7 @@ Describe 'Test-Command' {
     }
   }
 
-  Context 'Match-Output' {
+  Context 'Test-Output' {
     It 'Write-Output, success stream (1)' {
       Test-Command -Command 'Write-Output something' -Match 'something' |
         Should -BeTrue

--- a/General/Test-Command.Tests.ps1
+++ b/General/Test-Command.Tests.ps1
@@ -11,10 +11,6 @@ Describe 'Test-Command' {
     Get-Help Test-Command | Out-String |
       Should -MatchExactly 'SYNOPSIS' -Because $msg_documentation
   }
-  It 'supports -WhatIf and -Confirm' {
-    Get-Command -Name Test-Command -Syntax |
-      Should -Match '-Whatif.*-Confirm'
-  }
 
   Context 'Test-ErrorFree' {
     It 'Write-Host' {

--- a/General/Test-Command.psm1
+++ b/General/Test-Command.psm1
@@ -45,7 +45,6 @@ Set-StrictMode -Version Latest
   Not capable of containing $Hosts.SetShouldExit().
 #>
 function Test-Command {
-  [CmdletBinding(SupportsShouldProcess,ConfirmImpact='Low')]
   [OutputType([Bool])]
   param(
     [Parameter(Position=0,Mandatory)]
@@ -76,7 +75,6 @@ function Test-Command {
 ##====--------------------------------------------------------------------====##
 
 function Test-Output {
-  [CmdletBinding(SupportsShouldProcess,ConfirmImpact='Low')]
   param(
     [ValidateNotNullOrEmpty()]
     [String]$Command,
@@ -101,7 +99,6 @@ function Test-Output {
 
 # check if command executes without error
 function Test-ErrorFree {
-  [CmdletBinding(SupportsShouldProcess,ConfirmImpact='Low')]
   param(
     [ValidateNotNullOrEmpty()]
     [String]$Command,

--- a/General/Test-Command.psm1
+++ b/General/Test-Command.psm1
@@ -75,6 +75,8 @@ function Test-Command {
 ##====--------------------------------------------------------------------====##
 
 function Test-Output {
+  [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSPossibleIncorrectUsageOfRedirectionOperator', '', Scope='Function')]
   param(
     [ValidateNotNullOrEmpty()]
     [String]$Command,

--- a/General/Test-Command.psm1
+++ b/General/Test-Command.psm1
@@ -66,16 +66,16 @@ function Test-Command {
     [Switch]$IgnoreExitCode
   )
   if ($Match) {
-    return Match-Output -Command:$Command -Match:$Match
+    return Test-Output -Command:$Command -Match:$Match
   } elseif ($cMatch) {
-    return Match-Output -Command:$Command -Match:$cMatch -CaseSensitive
+    return Test-Output -Command:$Command -Match:$cMatch -CaseSensitive
   } else {
     return Test-ErrorFree $Command -IgnoreExitCode:$IgnoreExitCode
   }
 }
 ##====--------------------------------------------------------------------====##
 
-function Match-Output {
+function Test-Output {
   [CmdletBinding(SupportsShouldProcess,ConfirmImpact='Low')]
   param(
     [ValidateNotNullOrEmpty()]

--- a/General/Test-Command.psm1
+++ b/General/Test-Command.psm1
@@ -92,7 +92,7 @@ function Test-Output {
         return $true
       }
     }
-  } catch {}
+  } catch { Write-Verbose '' }
   return $false
 }
 ##====--------------------------------------------------------------------====##

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,36 @@
+# Configuration for PSScriptAnalyzer
+# https://github.com/PowerShell/PSScriptAnalyzer#explicit
+#
+# Run the tests from the project root:
+#  Invoke-ScriptAnalyzer -Path .\ -Recurse -ReportSummary
+# List suppressed warnings: -SuppressedOnly
+#
+# Local rule suppressing:
+#  .NET: SuppressMessageAttribute
+#  [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+#    'RuleName',
+#    '', # CheckId: name of parameter (required)
+#    Justification = 'Just an example',
+#    Scope = 'Function' # Function|Class
+#    Target = '.*' # Regex and glob matching class or function
+#  )]
+#
+
+@{
+  #Severity = @('Error', 'Warning', 'Information')
+  #IncludeDefaultRules = $true
+  #IncludeRules = @()
+  ExcludeRules = @(
+    # TODO $Error in Send-Message (major change)
+    'PSAvoidAssignmentToAutomaticVariable',
+    'PSAvoidGlobalVars',            # TODO local suppression does not work
+    'PSAvoidUsingInvokeExpression', # TODO
+    'PSAvoidUsingWriteHost',        # TODO
+    # '*' is not measurable slower module loading, sensitive to errors.
+    # Note: here '*' is only used in module manifest loading other manifests.
+    'PSUseToExportFieldsInManifest',
+    # No plans to conform to this.
+    'PSUseBOMForUnicodeEncodedFile'
+  )
+
+}

--- a/RunTests.ps1
+++ b/RunTests.ps1
@@ -97,10 +97,11 @@ Send-TestResult -File $OutputFile -Format $OutputFormatUpload `
   -WhatIf:$UseWhatif
 if ($Coverage) {
   try {
-    Send-Codecov -File $CodeCoverageOutputFile -BuildName:$BuildName -Flag:$Flag `
-      -Whatif:$UseWhatif
+    Send-Codecov -File $CodeCoverageOutputFile -BuildName:$BuildName `
+      -Flag:$Flag -Whatif:$UseWhatif
   } catch {
     # ignore exit-code
+    Write-Verbose 'Send-Codecov failed'
   }
 }
 Write-Verbose 'Run Pester unit tests ... done'

--- a/RunTests.ps1
+++ b/RunTests.ps1
@@ -26,8 +26,12 @@ $Flag = 'ci_scripts'
 ##====--------------------------------------------------------------------====##
 Import-Module "${PSScriptRoot}\AppVeyor\Send-Message.psd1"
 
-( Resolve-Path "${PSScriptRoot}\*.psd1", "${PSScriptRoot}\*\*.psd1" |
-    Test-ModuleManifest | Format-Table -Wrap -AutoSize | Out-String
+( Resolve-Path ".\*.psd1", ".\*\*.psd1" |
+  ForEach-Object -Process {
+    if (-not ($_.Path -match '.*PSScriptAnalyzerSettings\.psd1$') ) {
+      Test-ModuleManifest -Path $_
+    }
+  } | Format-Table -Wrap -AutoSize | Out-String
 ).Trim() -replace '[ ]*(\r?\n)','$1' |
   Send-Message -Info -Message 'Detected Modules:'
 

--- a/local/CI.Tests.ps1
+++ b/local/CI.Tests.ps1
@@ -60,17 +60,12 @@ Describe 'Assert-Windows' {
     }
   }
   It 'expected output' {
-    if ($PSVersionTable.PSVersion.Major -lt 6) {
+    if ((Get-CimInstance CIM_OperatingSystem).Caption -Match 'Windows') {
       Assert-Windows | Should -Be $true
-      (Get-WmiObject Win32_OperatingSystem).Caption | Should -Match 'Windows'
+      (Get-CimInstance CIM_OperatingSystem).Caption |
+        Should -Match 'Microsoft Windows'
     } else {
-      if ((Get-CimInstance CIM_OperatingSystem).Caption -Match 'Windows') {
-        Assert-Windows | Should -Be $true
-        (Get-CimInstance CIM_OperatingSystem).Caption |
-          Should -Match 'Microsoft Windows'
-      } else {
-        Assert-Windows | Should -Be $false
-      }
+      Assert-Windows | Should -Be $false
     }
   }
   $original_CI_WINDOWS = $env:CI_WINDOWS

--- a/local/CI.psm1
+++ b/local/CI.psm1
@@ -18,7 +18,7 @@ function Assert-CI {
   Checks if executed on the Microsoft Windows Platform.
 #>
 function Assert-Windows {
-  if ($env:CI_WINDOWS -ne $null) {
+  if ($null -ne $env:CI_WINDOWS) {
     ### Temporary - old build agent. ###########################################
     return ($env:CI_WINDOWS -eq 'true')
     <### new build agent.

--- a/local/Get-CommonFlagsCaller.psm1
+++ b/local/Get-CommonFlagsCaller.psm1
@@ -52,7 +52,7 @@ function Get-CommonFlagsCaller {
 
     # Get variable from caller
     $CallerVar = $Cmdlet.SessionState.PSVariable.Get($Preferences[$Flag])
-    if ($CallerVar -eq $null) { continue }
+    if ($null -eq $CallerVar) { continue }
     Write-Debug ($Flag + ': ' + $CallerVar.Value)
 
     # Set in calling scope


### PR DESCRIPTION
CodeFactor.io now supports the PSScriptAnalyzer.

Apply fixes and suppress some warnings locally.
No functional changes.

Some checks disabled:
 -  'PSAvoidAssignmentToAutomaticVariable', requires a major change to the interface of `Send-Message`.
 - 'PSAvoidGlobalVars', used for some shared data for tests.
 - 'PSAvoidUsingInvokeExpression', alternative needs some investigation.
 - 'PSAvoidUsingWriteHost', used for consistent output. Needs investigation.
 - 'PSUseToExportFieldsInManifest', will not change. '*' does not result in measurable slower module loading and is only used in module manifest loading other manifests.
  And manually supplying the names is way too sensitive to errors.
 - 'PSUseBOMForUnicodeEncodedFile', No plans to conform to this.
