### PR TITLE
+ Show-SystemInfo: Ninja-build version

### DIFF
--- a/AppVeyor/AppVeyor.psd1
+++ b/AppVeyor/AppVeyor.psd1
@@ -1,7 +1,7 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = ''
-ModuleVersion = '0.4.1'
+ModuleVersion = '0.4.2'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/AppVeyor/Show-SystemInfo.Tests.ps1
+++ b/AppVeyor/Show-SystemInfo.Tests.ps1
@@ -176,6 +176,18 @@ Describe 'Internal Show-<software>Version' {
         Show-VcpkgVersion | Should -match '^([0-9]+\.)+[0-9]+'
       }
     }
+    Context 'Ninja' {
+      $available = $(Test-Command 'ninja --version')
+      It 'no throw' {
+          { Show-NinjaVersion } | Should -not -Throw
+      }
+      It 'return version number' {
+        if (-not $available) {
+          Set-ItResult -Inconclusive -Because ('no Ninja')
+        }
+        Show-NinjaVersion | Should -match '^([0-9]+\.)+[0-9]+'
+      }
+    }
     Context 'mock software unavailable' {
       Mock Test-Command { return $false } -ModuleName Show-SystemInfo
       It 'CMake' {
@@ -195,6 +207,9 @@ Describe 'Internal Show-<software>Version' {
       }
       It 'vcpkg' {
         Show-VcpkgVersion | Should -MatchExactly ' ?'
+      }
+      It 'Ninja' {
+        Show-NinjaVersion | Should -MatchExactly ' ?'
       }
     }
   }
@@ -236,6 +251,9 @@ Describe 'Show-SystemInfo' {
     }
     It 'no throw on -Vcpkg' {
       { Show-SystemInfo -Vcpkg } | Should -not -Throw
+    }
+    It 'no throw on -Ninja' {
+      { Show-SystemInfo -Ninja } | Should -not -Throw
     }
     It 'no throw on -All' {
       { Show-SystemInfo -All } | Should -not -Throw

--- a/AppVeyor/Show-SystemInfo.psd1
+++ b/AppVeyor/Show-SystemInfo.psd1
@@ -6,7 +6,7 @@
 #>
 @{
 RootModule = 'Show-SystemInfo.psm1'
-ModuleVersion = '0.3.2'
+ModuleVersion = '0.4.0'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'

--- a/AppVeyor/Show-SystemInfo.psm1
+++ b/AppVeyor/Show-SystemInfo.psm1
@@ -41,6 +41,9 @@ Set-StrictMode -Version Latest
   LLVM/clang:         8.0.0
   CMake:              3.14.4
   Python:             2.7.16
+  Curl:               7.55.1
+  Ninja:              1.10.0
+  vcpkg:              2020.02.04-nohash
   ------------------------------------------------------------------------------
   Initial path:       C:\projects\sampleproject
 #>
@@ -58,6 +61,7 @@ function Show-SystemInfo {
     [switch]$Python,
     [switch]$SevenZip,
     [switch]$Curl,
+    [switch]$Ninja,
     [switch]$Vcpkg
   )
   Begin
@@ -124,6 +128,7 @@ function Show-SystemInfo {
     if ($CMake -or $All)    { $out += Join-Info CMake $(Show-CMakeVersion) }
     if ($Python -or $All)   { $out += Join-Info Python $(Show-PythonVersion) }
     if ($Curl -or $All)     { $out += Join-Info Curl $(Show-CurlVersion) }
+    if ($Ninja -or $All)    { $out += Join-Info Ninja $(Show-NinjaVersion) }
     if ($Vcpkg -or $All)    { $out += Join-Info vcpkg $(Show-VcpkgVersion) }
 
     if ($Path) { Show-EnvPath }
@@ -274,6 +279,18 @@ function Show-VcpkgVersion {
       (vcpkg version | Select-String -Pattern 'version [0-9]') -split ' ' |
         Select-String -Pattern '^[0-9].+'
     )
+  } else { return ' ?' }
+}
+
+<#
+.SYNOPSIS
+  Acquire the version number from Ninja-build.
+#>
+function Show-NinjaVersion {
+  [OutputType([String])]
+  param()
+  if (Test-Command 'ninja --version') {
+    return $(ninja --version)
   } else { return ' ?' }
 }
 

--- a/AppVeyorHelpers.psd1
+++ b/AppVeyorHelpers.psd1
@@ -7,7 +7,7 @@
 @{
 ##====--------------------------------------------------------------------====##
 RootModule = ''
-ModuleVersion = '0.14.0'
+ModuleVersion = '0.14.1'
 Author = 'Roelf-Jilling Wolthuis'
 Copyright = 'Copyright (c) 2019 Farwaykorse (R-J Wolthuis).
 Code released under the MIT license.'


### PR DESCRIPTION
Add the installed Ninja version to the SystemInfo opening text for the `-All` and `-Ninja` flags.

Since [2020-01-18](https://www.appveyor.com/updates/2020/01/18/) Ninja comes pre-installed on the VS2015, VS2017 and VS2019 images.

Version update to v0.14.1.